### PR TITLE
add required and changes to match CEM proposal

### DIFF
--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -322,8 +322,6 @@ The generator cost model is specified by the following fields.
 | -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
 | `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
 | `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
-| `startup`            | `0.0`             | `Real`         | $     | opf      | Startup cost                                              |
-| `shutdown`           | `0.0`             | `Real`         | $     | opf      | Shutdown cost                                             |
 
 ### Photovoltaic Systems (`solar`)
 
@@ -350,8 +348,6 @@ The cost model for a photovoltaic system currently matches that of generators.
 | -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
 | `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
 | `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
-| `startup`            | `0.0`             | `Real`         | $     | opf      | Startup cost                                              |
-| `shutdown`           | `0.0`             | `Real`         | $     | opf      | Shutdown cost                                             |
 
 ### Wind Turbine Systems (`wind`)
 

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -27,7 +27,7 @@ Valid component types are those that are documented in the sectios below. Each c
 
 Each edge or node component (_i.e._ all those that are not data objects or buses), are expected to have `status` fields to specify whether the component is active or disabled, `bus` or `f_bus` and `t_bus`, to specify the buses that are connected to the component, and `connections` or `f_connections` and `t_connections`, to specify the terminals of the buses that are actively connected in an ordered list. Terminals/connections can be any immutable value, as can bus ids.
 
-Parameter values on components are expected to be specified in SI units by default (where applicable) in the engineering data model. Relevant expected units are noted in the sections below. Where units is listed as watt, real units will be watt * `sbase`. Where units are listed as volt/var, real units will be volt/var * `v_var_scalar`, and multiplied by `vnom`, where that value exists.
+Parameter values on components are expected to be specified in SI units by default (where applicable) in the engineering data model. Relevant expected units are noted in the sections below. Where units is listed as watt, real units will be watt * `v_var_scalar`. Where units are listed as volt/var, real units will be volt/var * `v_var_scalar`, and multiplied by `vnom`, where that value exists.
 
 TODO: Specify units on each component
 

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -60,20 +60,20 @@ The data model below allows us to include buses of arbitrary many terminals (_i.
 - underground lines with multiple neutrals which are not joined at every bus;
 - distribution lines that carry several conventional lines in parallel (see for example the quad circuits in NEVTestCase).
 
-| Name             | Default     | Type            | Units  | Required | Description                                                                                                 |
-| ---------------- | ----------- | --------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `terminals`      | `[1,2,3,4]` | `Vector{Any}`   |        | always   | Terminals for which the bus has active connections                                                          |
-| `vm_lb`          |             | `Vector{Real}`  |        | opf      | Minimum conductor-to-ground voltage magnitude, `size=nphases`                                               |
-| `vm_ub`          |             | `Vector{Real}`  |        | opf      | Maximum conductor-to-ground voltage magnitude, `size=nphases`                                               |
-| `vm_pair_ub`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                                                                   |
-| `vm_pair_lb`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                                                                   |
-| `grounded`       | `[]`        | `Vector{Any}`   |        |          | List of terminals which are grounded                                                                        |
-| `rg`             | `[]`        | `Vector{Real}`  |        |          | Resistance of each defined grounding, `size=length(grounded)`                                               |
-| `xg`             | `[]`        | `Vector{Real}`  |        |          | Reactance of each defined grounding, `size=length(grounded)`                                                |
-| `vm`             |             | `Vector{Real}`  | volt   |          | Voltage magnitude at bus                                                                                    |
-| `va`             |             | `Vector{Real}`  | degree |          | Voltage angle at bus                                                                                        |
-| `status`         | `1`         | `Bool`          |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |             | `Any`           |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default     | Type            | Units  | Required | Description                                                                                                                          |
+| ---------------- | ----------- | --------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `terminals`      | `[1,2,3,4]` | `Vector{Any}`   |        | always   | Terminals for which the bus has active connections                                                                                   |
+| `vm_lb`          |             | `Vector{Real}`  |        | opf      | Minimum conductor-to-ground voltage magnitude, `size=nphases`                                                                        |
+| `vm_ub`          |             | `Vector{Real}`  |        | opf      | Maximum conductor-to-ground voltage magnitude, `size=nphases`                                                                        |
+| `vm_pair_ub`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                                                                                            |
+| `vm_pair_lb`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                                                                                            |
+| `grounded`       | `[]`        | `Vector{Any}`   |        |          | List of terminals which are grounded                                                                                                 |
+| `rg`             | `[]`        | `Vector{Real}`  |        |          | Resistance of each defined grounding, `size=length(grounded)`                                                                        |
+| `xg`             | `[]`        | `Vector{Real}`  |        |          | Reactance of each defined grounding, `size=length(grounded)`                                                                         |
+| `vm`             |             | `Vector{Real}`  | volt   |          | Voltage magnitude at bus                                                                                                             |
+| `va`             |             | `Vector{Real}`  | degree |          | Voltage angle at bus                                                                                                                 |
+| `status`         | `1`         | `Bool`          |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                              |
+| `{}_time_series` |             | `Any`           |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `vm`, `va`, `vm_lb`, `vm_ub` |
 
 The tricky part is how to encode bounds for these type of buses. The most general is defining a list of three-tuples. Take for example a typical bus in a three-phase, four-wire network, where `terminals=[a,b,c,n]`. Such a bus might have
 
@@ -127,28 +127,28 @@ These objects represent edges on the power grid and therefore require `f_bus` an
 
 This is a pi-model branch. When a `linecode` is given, and any of `rs`, `xs`, `b_fr`, `b_to`, `g_fr` or `g_to` are specified, any of those overwrite the values on the linecode.
 
-| Name             | Default | Type           | Units            | Required     | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ---------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
-| `f_bus`          |         | `Any`          |                  | always       | id of from-side bus connection                                                                              |
-| `t_bus`          |         | `Any`          |                  | always       | id of to-side bus connection                                                                                |
-| `f_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `f_bus` it connects                                  |
-| `t_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `t_bus` it connects                                  |
-| `linecode`       |         | `Any`          |                  | `!rs && !xs` | id of an associated linecode                                                                                |
-| `rs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series resistance matrix, `size=(nconductors,nconductors)`                                                  |
-| `xs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series reactance matrix, `size=(nconductors,nconductors)`                                                   |
-| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side conductance, `size=(nconductors,nconductors)`                                                     |
-| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side susceptance, `size=(nconductors,nconductors)`                                                     |
-| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side conductance, `size=(nconductors,nconductors)`                                                       |
-| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side susceptance, `size=(nconductors,nconductors)`                                                       |
-| `length`         | `1.0`   | `Real`         | meter            |              | Length of the line                                                                                          |
-| `cm_ub`          |         | `Vector{Real}` | amp              | opf          | Symmetrically applicable current rating, `size=nconductors`                                                 |
-| `sm_ub`          |         | `Vector{Real}` | watt             | opf          | Symmetrically applicable power rating, `size=nconductors`                                                   |
-| `pl_fr`          |         | `Vector{Real}` | watt             |              | Present active power flow on the from-side                                                                  |
-| `ql_fr`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the from-side                                                                |
-| `pl_to`          |         | `Vector{Real}` | watt             |              | Present active power flow on the to-side                                                                    |
-| `ql_to`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the to-side                                                                  |
-| `status`         | `1`     | `Bool`         |                  | always       | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |         | `Any`          |                  |              | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units            | Required     | Description                                                                                                                          |
+| ---------------- | ------- | -------------- | ---------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `f_bus`          |         | `Any`          |                  | always       | id of from-side bus connection                                                                                                       |
+| `t_bus`          |         | `Any`          |                  | always       | id of to-side bus connection                                                                                                         |
+| `f_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `f_bus` it connects                                                           |
+| `t_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `t_bus` it connects                                                           |
+| `linecode`       |         | `Any`          |                  | `!rs && !xs` | id of an associated linecode                                                                                                         |
+| `rs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series resistance matrix, `size=(nconductors,nconductors)`                                                                           |
+| `xs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series reactance matrix, `size=(nconductors,nconductors)`                                                                            |
+| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side conductance, `size=(nconductors,nconductors)`                                                                              |
+| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side susceptance, `size=(nconductors,nconductors)`                                                                              |
+| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side conductance, `size=(nconductors,nconductors)`                                                                                |
+| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side susceptance, `size=(nconductors,nconductors)`                                                                                |
+| `length`         | `1.0`   | `Real`         | meter            |              | Length of the line                                                                                                                   |
+| `cm_ub`          |         | `Vector{Real}` | amp              | opf          | Symmetrically applicable current rating, `size=nconductors`                                                                          |
+| `sm_ub`          |         | `Vector{Real}` | watt             | opf          | Symmetrically applicable power rating, `size=nconductors`                                                                            |
+| `pl_fr`          |         | `Vector{Real}` | watt             |              | Present active power flow on the from-side                                                                                           |
+| `ql_fr`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the from-side                                                                                         |
+| `pl_to`          |         | `Vector{Real}` | watt             |              | Present active power flow on the to-side                                                                                             |
+| `ql_to`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the to-side                                                                                           |
+| `status`         | `1`     | `Bool`         |                  | always       | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                              |
+| `{}_time_series` |         | `Any`          |                  |              | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `rs`, `xs`, `cm_ub`, `sm_ub` |
 
 - which takes presidence, `cm_ub` or `sm_ub` if both are specified?
 
@@ -158,62 +158,61 @@ Add example for linecodes/lines off different size (conductors)
 
 These are n-winding (`nwinding`), n-phase (`nphase`), lossy transformers. Note that most properties are now Vectors (or Vectors of Vectors), indexed over the windings.
 
-| Name             | Default                                | Type                   | Units | Required                           | Description                                                                                                    |
-| ---------------- | -------------------------------------- | ---------------------- | ----- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `buses`          |                                        | `Vector{Any}`          |       | `!f_bus && !t_bus`                 | List of bus for each winding, `size=nwindings`                                                                 |
-| `connections`    |                                        | `Vector{Vector{Any}}`  |       | `!f_connections && !t_connections` | List of connection for each winding, `size=((nconductors), nwindings)`                                         |
-| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       | always                             | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
-| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |                                    | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
-| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |                                    | List of the winding resistance for each winding                                                                |
-| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |                                    | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
-| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
-| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
-| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |                                    | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
-| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |                                    | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
-| `status`         | `1`                                    | `Bool`                 |       | always                             | `1` or `0`. Indicates if component is enabled or disabled, respectively                                        |
-| `{}_time_series` |                                        | `Any`                  |       |                                    | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter    |
+| Name             | Default                                | Type                   | Units | Required                           | Description                                                                                                                                        |
+| ---------------- | -------------------------------------- | ---------------------- | ----- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `buses`          |                                        | `Vector{Any}`          |       | `!f_bus && !t_bus`                 | List of bus for each winding, `size=nwindings`                                                                                                     |
+| `connections`    |                                        | `Vector{Vector{Any}}`  |       | `!f_connections && !t_connections` | List of connection for each winding, `size=((nconductors), nwindings)`                                                                             |
+| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       | always                             | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                                                     |
+| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |                                    | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements                                     |
+| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |                                    | List of the winding resistance for each winding                                                                                                    |
+| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |                                    | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                                                               |
+| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                        |
+| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                    |
+| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |                                    | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                            |
+| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |                                    | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`                                                 |
+| `status`         | `1`                                    | `Bool`                 |       | always                             | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                            |
+| `{}_time_series` |                                        | `Any`                  |       |                                    | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `tm`, `tm_fix`, `tm_set`, `tm_ub`, `tm_lb` |
 
 #### Assymetric, Lossless, Two-Winding (AL2W) Transformers
 
 Special case of the Generic transformer. These are transformers are assymetric (A), lossless (L) and two-winding (2W). Assymetric refers to the fact that the secondary is always has a `wye` configuration, whilst the primary can be `delta`. The table below indicates alternate, more simple ways to specify the special case of an AL2W Transformer. `xsc` and `rs` cannot be specified for an AL2W transformer.
 
-| Name             | Default               | Type           | Units | Required       | Description                                                                                                 |
-| ---------------- | --------------------- | -------------- | ----- | -------------- | ----------------------------------------------------------------------------------------------------------- |
-| `f_bus`          |                       | `Any`          |       | `!buses`       | Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                       |
-| `t_bus`          |                       | `Any`          |       | `!buses`       | Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                      |
-| `f_connections`  |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`                 |
-| `t_connections`  |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`                 |
-| `configuration`  | `"wye"`               | `String`       |       |                | `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"`     |
-| `tm_nom`         | `1.0`                 | `Real`         |       |                | Nominal tap ratio for the transformer (multiplier)                                                          |
-| `tm_ub`          |                       | `Vector{Real}` |       | opf            | Maximum tap ratio for each phase (base=`tm_nom`)                                                            |
-| `tm_lb`          |                       | `Vector{Real}` |       | opf            | Minimum tap ratio for each phase (base=`tm_nom`)                                                            |
-| `tm_set`         | `fill(1.0, nphases)`  | `Vector{Real}` |       |                | Set tap ratio for each phase (base=`tm_nom`)                                                                |
-| `tm_fix`         | `fill(true, nphases)` | `Vector{Real}` |       |                | Indicates for each phase whether the tap ratio is fixed                                                     |
-| `{}_time_series` |                       | `Any`          |       |                | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name            | Default               | Type           | Units | Required       | Description                                                                                             |
+| --------------- | --------------------- | -------------- | ----- | -------------- | ------------------------------------------------------------------------------------------------------- |
+| `f_bus`         |                       | `Any`          |       | `!buses`       | Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                   |
+| `t_bus`         |                       | `Any`          |       | `!buses`       | Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                  |
+| `f_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
+| `t_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
+| `configuration` | `"wye"`               | `String`       |       |                | `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"` |
+| `tm_nom`        | `1.0`                 | `Real`         |       |                | Nominal tap ratio for the transformer (multiplier)                                                      |
+| `tm_ub`         |                       | `Vector{Real}` |       | opf            | Maximum tap ratio for each phase (base=`tm_nom`)                                                        |
+| `tm_lb`         |                       | `Vector{Real}` |       | opf            | Minimum tap ratio for each phase (base=`tm_nom`)                                                        |
+| `tm_set`        | `fill(1.0, nphases)`  | `Vector{Real}` |       |                | Set tap ratio for each phase (base=`tm_nom`)                                                            |
+| `tm_fix`        | `fill(true, nphases)` | `Vector{Real}` |       |                | Indicates for each phase whether the tap ratio is fixed                                                 |
 
 ### Switches (`switch`)
 
 Switches without any of `rs`, `xs`, `g_fr`, `b_fr`, `g_to`, `b_to` defined are assumed to be lossless. If lossy parameters are defined, `switch` objects will be decomposed into virtual `branch` & `bus`, and an ideal `switch`.
 
-| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `f_bus`          |         | `Any`          |         | always   | id of from-side bus connection                                                                              |
-| `t_bus`          |         | `Any`          |         | always   | id of to-side bus connection                                                                                |
-| `f_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `f_bus` it connects                                  |
-| `t_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `t_bus` it connects                                  |
-| `cm_ub`          |         | `Vector{Real}` | amp     | opf      | Symmetrically applicable current rating                                                                     |
-| `sm_ub`          |         | `Vector{Real}` | watt    | opf      | Symmetrically applicable power rating                                                                       |
-| `rs`             |         | `Matrix{Real}` | ohm     |          | Series resistance matrix, `size=(nphases,nphases)`                                                          |
-| `xs`             |         | `Matrix{Real}` | ohm     |          | Series reactance matrix, `size=(nphases,nphases)`                                                           |
-| `g_fr`           |         | `Matrix{Real}` | siemens |          | From-side conductance, `size=(nphases,nphases)`,                                                            |
-| `b_fr`           |         | `Matrix{Real}` | siemens |          | From-side susceptance, `size=(nphases,nphases)`                                                             |
-| `g_to`           |         | `Matrix{Real}` | siemens |          | To-side conductance, `size=(nphases,nphases)`                                                               |
-| `b_to`           |         | `Matrix{Real}` | siemens |          | To-side susceptance, `size=(nphases,nphases)`                                                               |
-| `psw`            |         | `Vector{Real}` | watt    |          | Present value of active power flow across the switch                                                        |
-| `qsw`            |         | `Vector{Real}` | var     |          | Present value of reactive power flow across the switch                                                      |
-| `state`          | `1`     | `Int`          |         | always   | `1`: closed or `0`: open, to indicate state of switch                                                       |
-| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                                                   |
+| ---------------- | ------- | -------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `f_bus`          |         | `Any`          |         | always   | id of from-side bus connection                                                                                                                |
+| `t_bus`          |         | `Any`          |         | always   | id of to-side bus connection                                                                                                                  |
+| `f_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `f_bus` it connects                                                                    |
+| `t_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `t_bus` it connects                                                                    |
+| `cm_ub`          |         | `Vector{Real}` | amp     | opf      | Symmetrically applicable current rating                                                                                                       |
+| `sm_ub`          |         | `Vector{Real}` | watt    | opf      | Symmetrically applicable power rating                                                                                                         |
+| `rs`             |         | `Matrix{Real}` | ohm     |          | Series resistance matrix, `size=(nphases,nphases)`                                                                                            |
+| `xs`             |         | `Matrix{Real}` | ohm     |          | Series reactance matrix, `size=(nphases,nphases)`                                                                                             |
+| `g_fr`           |         | `Matrix{Real}` | siemens |          | From-side conductance, `size=(nphases,nphases)`,                                                                                              |
+| `b_fr`           |         | `Matrix{Real}` | siemens |          | From-side susceptance, `size=(nphases,nphases)`                                                                                               |
+| `g_to`           |         | `Matrix{Real}` | siemens |          | To-side conductance, `size=(nphases,nphases)`                                                                                                 |
+| `b_to`           |         | `Matrix{Real}` | siemens |          | To-side susceptance, `size=(nphases,nphases)`                                                                                                 |
+| `psw`            |         | `Vector{Real}` | watt    |          | Present value of active power flow across the switch                                                                                          |
+| `qsw`            |         | `Vector{Real}` | var     |          | Present value of reactive power flow across the switch                                                                                        |
+| `state`          | `1`     | `Int`          |         | always   | `1`: closed or `0`: open, to indicate state of switch                                                                                         |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                       |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `state`, `rs`, `xs`, `cm_ub`, `sm_ub` |
 
 #### Fuses (`fuse`)
 
@@ -238,41 +237,43 @@ These are objects that have single bus connections. Every object will have at le
 
 ### Shunts (`shunt`)
 
-| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
-| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                        |
-| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
-| `gs`             |         | `Matrix{Real}` | siemens | always   | Conductance, `size=(nphases,nphases)`                                                                       |
-| `bs`             |         | `Matrix{Real}` | siemens | always   | Susceptance, `size=(nphases,nphases)`                                                                       |
-| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                        |
+| ---------------- | ------- | -------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                               |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                               |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                       |
+| `gs`             |         | `Matrix{Real}` | siemens | always   | Conductance, `size=(nphases,nphases)`                                                                              |
+| `bs`             |         | `Matrix{Real}` | siemens | always   | Susceptance, `size=(nphases,nphases)`                                                                              |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                            |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `gs`, `bs` |
 
 #### Shunt Capacitors (`shunt_capacitor`)
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
-| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
-| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                    |
-| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only        |
-| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                               |
-| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                |
-| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                  |
+| ---------------- | ------- | -------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                         |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                     |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only         |
+| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                                |
+| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                 |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                      |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `bs` |
 
 #### Shunt Reactors (`shunt_reactor`)
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
-| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
-| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                    |
-| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only        |
-| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                               |
-| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                |
-| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                  |
+| ---------------- | ------- | -------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                         |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                     |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only         |
+| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                                |
+| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                 |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                      |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `bs` |
 
 ### Loads (`load`)
 
@@ -286,7 +287,7 @@ This is a special case of `shunt` with its own data category for easier tracking
 | `qd_nom`         |                    | `Vector{Real}` | var   | always   | Nominal reactive load, with respect to `vnom`, `size=nphases`                                                                           |
 | `vnom`           |                    | `Real`         | volt  | always   | Nominal voltage (multiplier)                                                                                                            |
 | `status`         | `1`                | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                 |
-| `{}_time_series` |                    | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter                             |
+| `{}_time_series` |                    | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `pd_nom`, `qd_nom`              |
 
 #### `model="exponential"`
 
@@ -321,32 +322,33 @@ This is a special case of `shunt` with its own data category for easier tracking
 | `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                                                                                                                       |
 | `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                                                                                                                     |
 | `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                                                                                         |
-| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter                                                                                                     |
+| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `pg_lb`, `qg_lb`, `pg_ub`, `qg_ub`, `pg`, `qg`                                                          |
 
 #### `generator` Cost Model
 
 The generator cost model is specified by the following fields.
 
-| Name                 | Default           | Type           | Units | Required | Description                                               |
-| -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
-| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
-| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
+| Name                 | Default           | Type           | Units | Required | Description                                                                                                                         |
+| -------------------- | ----------------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial                                                                           |
+| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                                                                                               |
+| `{}_time_series`     |                   | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `cost_pg_model`, `cost_pg_parameters` |
 
 ### Photovoltaic Systems (`solar`)
 
-| Name             | Default | Type           | Units | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                        |
-| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                        |
-| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
-| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                            |
-| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                            |
-| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                          |
-| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                          |
-| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                   |
-| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                 |
-| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units | Required | Description                                                                                                                                            |
+| ---------------- | ------- | -------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                                                                   |
+| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                                                                   |
+| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                                                           |
+| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                                                                       |
+| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                                                                       |
+| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                                                                     |
+| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                                                                     |
+| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                                                              |
+| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                                                            |
+| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                                |
+| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `pg_lb`, `qg_lb`, `pg_ub`, `qg_ub`, `pg`, `qg` |
 
 #### Irradiation Model
 
@@ -354,10 +356,11 @@ The generator cost model is specified by the following fields.
 
 The cost model for a photovoltaic system currently matches that of generators.
 
-| Name                 | Default           | Type           | Units | Required | Description                                               |
-| -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
-| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
-| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
+| Name                 | Default           | Type           | Units | Required | Description                                                                                                                         |
+| -------------------- | ----------------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial                                                                           |
+| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                                                                                               |
+| `{}_time_series`     |                   | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `cost_pg_model`, `cost_pg_parameters` |
 
 ### Wind Turbine Systems (`wind`)
 
@@ -369,45 +372,45 @@ A storage object is a flexible component that can represent a variety of energy 
 
 - How to include the inverter model for this? Similar issue as for a PV generator
 
-| Name                   | Default | Type           | Units   | Required | Description                                                                                                 |
-| ---------------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`                  |         | `Any`          |         | always   | id of bus connection                                                                                        |
-| `connections`          |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                        |
-| `configuration`        | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
-| `energy`               |         | `Real`         | watt-hr | always   | Stored energy                                                                                               |
-| `energy_ub`            |         | `Real`         |         | opf      |                                                                                                             |
-| `charge_ub`            |         | `Real`         |         | opf      |                                                                                                             |
-| `discharge_ub`         |         | `Real`         |         | opf      |                                                                                                             |
-| `sm_ub`                |         | `Vector{Real}` | watt    | opf      | Power rating, `size=nphases`                                                                                |
-| `cm_ub`                |         | `Vector{Real}` | amp     | opf      | Current rating, `size=nphases`                                                                              |
-| `charge_efficiency`    |         | `Real`         |         | always   |                                                                                                             |
-| `discharge_efficiency` |         | `Real`         |         | always   |                                                                                                             |
-| `qs_ub`                |         | `Vector{Real}` |         | opf      | Maximum reactive power injection, `size=nphases`                                                            |
-| `qs_lb`                |         | `Vector{Real}` |         | opf      | Minimum reactive power injection, `size=nphases`                                                            |
-| `rs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                             |
-| `xs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                             |
-| `pex`                  |         | `Real`         |         | always   | Total active power standby exogenous flow (loss)                                                            |
-| `qex`                  |         | `Real`         |         | always   | Total reactive power standby exogenous flow (loss)                                                          |
-| `ps`                   |         | `Vector{Real}` | watt    |          | Present active power injection                                                                              |
-| `qs`                   |         | `Vector{Real}` | var     |          | Present reactive power injection                                                                            |
-| `status`               | `1`     | `Bool`         |         | opf      | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series`       |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name                   | Default | Type           | Units   | Required | Description                                                                                                                                                                                                                             |
+| ---------------------- | ------- | -------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bus`                  |         | `Any`          |         | always   | id of bus connection                                                                                                                                                                                                                    |
+| `connections`          |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                                                                                                                                                    |
+| `configuration`        | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                                                                                                                                            |
+| `energy`               |         | `Real`         | watt-hr | always   | Stored energy                                                                                                                                                                                                                           |
+| `energy_ub`            |         | `Real`         |         | opf      |                                                                                                                                                                                                                                         |
+| `charge_ub`            |         | `Real`         |         | opf      |                                                                                                                                                                                                                                         |
+| `discharge_ub`         |         | `Real`         |         | opf      |                                                                                                                                                                                                                                         |
+| `sm_ub`                |         | `Vector{Real}` | watt    | opf      | Power rating, `size=nphases`                                                                                                                                                                                                            |
+| `cm_ub`                |         | `Vector{Real}` | amp     | opf      | Current rating, `size=nphases`                                                                                                                                                                                                          |
+| `charge_efficiency`    |         | `Real`         |         | always   |                                                                                                                                                                                                                                         |
+| `discharge_efficiency` |         | `Real`         |         | always   |                                                                                                                                                                                                                                         |
+| `qs_ub`                |         | `Vector{Real}` |         | opf      | Maximum reactive power injection, `size=nphases`                                                                                                                                                                                        |
+| `qs_lb`                |         | `Vector{Real}` |         | opf      | Minimum reactive power injection, `size=nphases`                                                                                                                                                                                        |
+| `rs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                                                                                                                                                         |
+| `xs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                                                                                                                                                         |
+| `pex`                  |         | `Real`         |         | always   | Total active power standby exogenous flow (loss)                                                                                                                                                                                        |
+| `qex`                  |         | `Real`         |         | always   | Total reactive power standby exogenous flow (loss)                                                                                                                                                                                      |
+| `ps`                   |         | `Vector{Real}` | watt    |          | Present active power injection                                                                                                                                                                                                          |
+| `qs`                   |         | `Vector{Real}` | var     |          | Present reactive power injection                                                                                                                                                                                                        |
+| `status`               | `1`     | `Bool`         |         | opf      | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                                                                                                                 |
+| `{}_time_series`       |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `energy`, `energy_ub`, `charge_ub`, `discharge_ub`, `charge_efficiency`, `discharge_efficiency`, `qs_ub`, `qs_lb`, `pex`, `qex` |
 
 ### Voltage Sources (`voltage_source`)
 
 A voltage source is a source of power at a set voltage magnitude and angle connected to a slack bus. If `rs` or `xs` are not specified, the voltage source is assumed to be lossless, otherwise virtual `branch` and `bus` will be created in the mathematical model to represent the internal losses of the voltage source.
 
-| Name             | Default         | Type           | Units  | Required | Description                                                                                                 |
-| ---------------- | --------------- | -------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |                 | `Any`          |        | always   | id of bus connection                                                                                        |
-| `connections`    |                 | `Vector{Any}`  |        | always   | Ordered list of connected conductors                                                                        |
-| `configuration`  | `"wye"`         | `String`       |        | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
-| `vm`             | `ones(nphases)` | `Vector{Real}` | volt   | always   | Voltage magnitude set at slack bus                                                                          |
-| `va`             | `0.0`           | `Real`         | degree |          | Voltage angle offset at slack bus                                                                           |
-| `rs`             |                 | `Matrix{Real}` | ohm    |          | Internal series resistance of voltage source, `size=(nconductors,nconductors)`                              |
-| `xs`             |                 | `Matrix{Real}` | ohm    |          | Internal series reactance of voltage soure, `size=(nconductors,nconductors)`                                |
-| `status`         | `1`             | `Bool`         |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |                 | `Any`          |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default         | Type           | Units  | Required | Description                                                                                                        |
+| ---------------- | --------------- | -------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `bus`            |                 | `Any`          |        | always   | id of bus connection                                                                                               |
+| `connections`    |                 | `Vector{Any}`  |        | always   | Ordered list of connected conductors                                                                               |
+| `configuration`  | `"wye"`         | `String`       |        | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                       |
+| `vm`             | `ones(nphases)` | `Vector{Real}` | volt   | always   | Voltage magnitude set at slack bus                                                                                 |
+| `va`             | `0.0`           | `Real`         | degree |          | Voltage angle offset at slack bus                                                                                  |
+| `rs`             |                 | `Matrix{Real}` | ohm    |          | Internal series resistance of voltage source, `size=(nconductors,nconductors)`                                     |
+| `xs`             |                 | `Matrix{Real}` | ohm    |          | Internal series reactance of voltage soure, `size=(nconductors,nconductors)`                                       |
+| `status`         | `1`             | `Bool`         |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                            |
+| `{}_time_series` |                 | `Any`          |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `status`, `vm`, `va` |
 
 ## Data Objects (codes, curves, shapes)
 
@@ -420,32 +423,32 @@ Linecodes are easy ways to specify properties common to multiple lines.
 - Should the linecode also include a `cm_ub` and `sm_ub`? I think not. `cm_ub` yes, `sm_ub` does not make sense. `sm_ub`, if desired, should be specified at the line level
 - Does `cmatrix` makes more sense than `g_fr, b_fr, g_to, b_to` when parametrized per length? No, enforce symmetry. If needed place a shunt or inject at low-level.
 
-| Name             | Default | Type           | Units            | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `rs`             |         | `Matrix{Real}` | ohm/meter        |          | Series resistance, `size=(nconductors,nconductors)`                                                         |
-| `xs`             |         | `Matrix{Real}` | ohm/meter        |          | Series reactance, `size=(nconductors,nconductors)`                                                          |
-| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side conductance, `size=(nconductors,nconductors)`                                                     |
-| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side susceptance, `size=(nconductors,nconductors)`                                                     |
-| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side conductance, `size=(nconductors,nconductors)`                                                       |
-| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side susceptance, `size=(nconductors,nconductors)`                                                       |
-| `cm_ub`          |         | `Vector{Real}` | ampere           |          | maximum current per conductor, symmetrically applicable                                                     |
-| `{}_time_series` |         | `Any`          |                  |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units            | Required | Description                                                                                                       |
+| ---------------- | ------- | -------------- | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `rs`             |         | `Matrix{Real}` | ohm/meter        |          | Series resistance, `size=(nconductors,nconductors)`                                                               |
+| `xs`             |         | `Matrix{Real}` | ohm/meter        |          | Series reactance, `size=(nconductors,nconductors)`                                                                |
+| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side conductance, `size=(nconductors,nconductors)`                                                           |
+| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side susceptance, `size=(nconductors,nconductors)`                                                           |
+| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side conductance, `size=(nconductors,nconductors)`                                                             |
+| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side susceptance, `size=(nconductors,nconductors)`                                                             |
+| `cm_ub`          |         | `Vector{Real}` | ampere           |          | maximum current per conductor, symmetrically applicable                                                           |
+| `{}_time_series` |         | `Any`          |                  |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `rs`, `xs`, `cm_ub` |
 
 ### Transformer Codes (`xfmrcode`)
 
 Transformer codes are easy ways to specify properties common to multiple transformers
 
-| Name             | Default                                | Type                   | Units | Required | Description                                                                                                    |
-| ---------------- | -------------------------------------- | ---------------------- | ----- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       |          | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
-| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |          | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
-| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |          | List of the winding resistance for each winding                                                                |
-| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |          | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
-| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       |          | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
-| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       |          | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
-| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |          | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
-| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |          | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
-| `{}_time_series` |                                        | `Any`                  |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter    |
+| Name             | Default                                | Type                   | Units | Required | Description                                                                                                                                               |
+| ---------------- | -------------------------------------- | ---------------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       |          | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                                                            |
+| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |          | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements                                            |
+| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |          | List of the winding resistance for each winding                                                                                                           |
+| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |          | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                                                                      |
+| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       |          | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                               |
+| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       |          | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                           |
+| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |          | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                                                                   |
+| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |          | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`                                                        |
+| `{}_time_series` |                                        | `Any`                  |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for `rs`, `xsc`, `tm_nom`, `tm_ub`, `tm_lb`, `tm_set`, `tm_fix` |
 
 ### Voltage Zones (`voltage_zone`)
 
@@ -472,9 +475,10 @@ Curve objects are functions f(x) that return single values for a given x. This i
 
 Time series objects are used to specify time series for _e.g._ load or generation forecasts.
 
-Every parameter for any component specified in this document can support a time series by appending `_time_series` to the parameter name. For example, for a `load`, if `pd_nom` is supposed to be a time series, the user would specify `"pd_nom_time_series" => time_series_id` where `time_series_id` is the `id` of an object in `time_series`, and has type `Any`.
+Some parameters for components specified in this document can support a time series by appending `_time_series` to the parameter name. For example, for a `load`, if `pd_nom` is supposed to be a time series, the user would specify `"pd_nom_time_series" => time_series_id` where `time_series_id` is the `id` of an object in `time_series`, and has type `Any`. The parameters that support time series will be specified in their respective sections above.
 
-| Name         | Default | Type           | Units | Required | Description                                                                                                                                                         |
-| ------------ | ------- | -------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `time`       |         | `Vector{Real}` | hour  | always   | Time points at which values are specified                                                                                                                           |
-| `multiplier` |         | `Vector{Real}` |       | always   | Multipers at each time step given in `time`. If `useactual`, multipliers do not multiply original values, but replace them on the objects to which they are applied |
+| Name      | Default | Type           | Units | Required | Description                                                                           |
+| --------- | ------- | -------------- | ----- | -------- | ------------------------------------------------------------------------------------- |
+| `time`    |         | `Vector{Real}` | hour  | always   | Time points at which values are specified                                             |
+| `values`  |         | `Vector{Real}` |       | always   | Multipers at each time step given in `time`                                           |
+| `replace` |         | `Bool`         |       | always   | Indicates to replace with data, instead of multiply. Will only work on non-Array data |

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -27,7 +27,7 @@ Valid component types are those that are documented in the sectios below. Each c
 
 Each edge or node component (_i.e._ all those that are not data objects or buses), are expected to have `status` fields to specify whether the component is active or disabled, `bus` or `f_bus` and `t_bus`, to specify the buses that are connected to the component, and `connections` or `f_connections` and `t_connections`, to specify the terminals of the buses that are actively connected in an ordered list. Terminals/connections can be any immutable value, as can bus ids.
 
-Parameter values on components are expected to be specified in SI units by default (where applicable) in the engineering data model. Relevant expected units are noted in the sections below.
+Parameter values on components are expected to be specified in SI units by default (where applicable) in the engineering data model. Relevant expected units are noted in the sections below. Where units is listed as watt, real units will be watt * `sbase`. Where units are listed as volt/var, real units will be volt/var * `v_var_scalar`, and multiplied by `vnom`, where that value exists.
 
 TODO: Specify units on each component
 
@@ -35,23 +35,23 @@ TODO: Specify units on each component
 
 At the root level of the data structure, the following fields can be found.
 
-| Name         | Default         | Type                 | Description                                                                                                                |
-| ------------ | --------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `name`       |                 | `String`             | (Optional) Case name                                                                                                       |
-| `data_model` | `"engineering"` | `String`             | `"engineering"`, `"mathematical"`, or `"dss"`. Type of the data model (this document describes `data_model="engineering"`) |
-| `settings`   | `Dict()`        | `Dict{String,<:Any}` | Base settings for the data model, see Settings section below for details                                                   |
+| Name         | Default         | Type                 | Required | Description                                                                                                                |
+| ------------ | --------------- | -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `name`       |                 | `String`             |          | Case name                                                                                                                  |
+| `data_model` | `"engineering"` | `String`             | always   | `"engineering"`, `"mathematical"`, or `"dss"`. Type of the data model (this document describes `data_model="engineering"`) |
+| `settings`   | `Dict()`        | `Dict{String,<:Any}` | always   | Base settings for the data model, see Settings section below for details                                                   |
 
 ## Settings (`settings`)
 
 At the root-level of the data model a `settings` dictionary object is expected, containing the following fields.
 
-| Name             | Default | Type   | Units | Description                                                    |
-| ---------------- | ------- | ------ | ----- | -------------------------------------------------------------- |
-| `v_var_scalar`   | `1e3`   | `Real` |       | Scalar for voltage values                                      |
-| `vbase`          |         | `Real` |       | Voltage base (_i.e._ basekv) at `base_bus`                     |
-| `sbase`          |         | `Real` |       | Power base (baseMVA) at `base_bus`                             |
-| `base_bus`       |         | `Any`  |       | id of bus at which `vbase` and `sbase` apply                   |
-| `base_frequency` | `60.0`  | `Real` | Hz    | Frequency base, _i.e._ the base frequency of the whole circuit |
+| Name             | Default | Type   | Units | Required | Description                                                    |
+| ---------------- | ------- | ------ | ----- | -------- | -------------------------------------------------------------- |
+| `v_var_scalar`   | `1e3`   | `Real` |       | always   | Scalar for voltage values                                      |
+| `vbase`          |         | `Real` |       | always   | Voltage base (_i.e._ basekv) at `base_bus`                     |
+| `sbase`          |         | `Real` |       | always   | Power base (baseMVA) at `base_bus`                             |
+| `base_bus`       |         | `Any`  |       | always   | id of bus at which `vbase` and `sbase` apply                   |
+| `base_frequency` | `60.0`  | `Real` | Hz    | always   | Frequency base, _i.e._ the base frequency of the whole circuit |
 
 ## Buses (`bus`)
 
@@ -60,29 +60,29 @@ The data model below allows us to include buses of arbitrary many terminals (_i.
 - underground lines with multiple neutrals which are not joined at every bus;
 - distribution lines that carry several conventional lines in parallel (see for example the quad circuits in NEVTestCase).
 
-| Name          | Default     | Type            | Units  | Description                                                                                          |
-| ------------- | ----------- | --------------- | ------ | ---------------------------------------------------------------------------------------------------- |
-| `terminals`   | `[1,2,3,4]` | `Vector{Any}`   |        | Terminals for which the bus has active connections                                                   |
-| `vm_min`      |             | `Vector{Real}`  |        | Minimum conductor-to-ground voltage magnitude, `size=nphases`                                        |
-| `vm_max`      |             | `Vector{Real}`  |        | Maximum conductor-to-ground voltage magnitude, `size=nphases`                                        |
-| `vm_pair_max` |             | `Vector{Tuple}` |        | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                                                            |
-| `vm_pair_min` |             | `Vector{Tuple}` |        | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                                                            |
-| `grounded`    | `[]`        | `Vector{Any}`   |        | List of terminals which are grounded                                                                 |
-| `rg`          | `[]`        | `Vector{Real}`  |        | Resistance of each defined grounding, `size=length(grounded)`                                        |
-| `xg`          | `[]`        | `Vector{Real}`  |        | Reactance of each defined grounding, `size=length(grounded)`                                         |
-| `vm`          |             | `Vector{Real}`  | volt   | (Optional) Voltage magnitude at bus                                                                  |
-| `va`          |             | `Vector{Real}`  | degree | (Optional) Voltage angle at bus                                                                      |
-| `status`      | `1`         | `Bool`          |        | `1` or `0`. Indicates if component is enabled or disabled, respectively                              |
+| Name         | Default     | Type            | Units  | Required | Description                                                             |
+| ------------ | ----------- | --------------- | ------ | -------- | ----------------------------------------------------------------------- |
+| `terminals`  | `[1,2,3,4]` | `Vector{Any}`   |        | always   | Terminals for which the bus has active connections                      |
+| `vm_lb`      |             | `Vector{Real}`  |        | opf      | Minimum conductor-to-ground voltage magnitude, `size=nphases`           |
+| `vm_ub`      |             | `Vector{Real}`  |        | opf      | Maximum conductor-to-ground voltage magnitude, `size=nphases`           |
+| `vm_pair_ub` |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                               |
+| `vm_pair_lb` |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                               |
+| `grounded`   | `[]`        | `Vector{Any}`   |        |          | List of terminals which are grounded                                    |
+| `rg`         | `[]`        | `Vector{Real}`  |        |          | Resistance of each defined grounding, `size=length(grounded)`           |
+| `xg`         | `[]`        | `Vector{Real}`  |        |          | Reactance of each defined grounding, `size=length(grounded)`            |
+| `vm`         |             | `Vector{Real}`  | volt   |          | Voltage magnitude at bus                                                |
+| `va`         |             | `Vector{Real}`  | degree |          | Voltage angle at bus                                                    |
+| `status`     | `1`         | `Bool`          |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
 
 The tricky part is how to encode bounds for these type of buses. The most general is defining a list of three-tuples. Take for example a typical bus in a three-phase, four-wire network, where `terminals=[a,b,c,n]`. Such a bus might have
 
-- phase-to-neutral bounds `vm_pn_max=250`, `vm_pn_min=210`
-- and phase-to-phase bounds `vm_pp_max=440`, `vm_pp_min=360`.
+- phase-to-neutral bounds `vm_pn_ub=250`, `vm_pn_lb=210`
+- and phase-to-phase bounds `vm_pp_ub=440`, `vm_pp_lb=360`.
 
 We can then define this equivalently as
 
-- `vm_pair_max = [(a,n,250), (b,n,250), (c,n,250), (a,b,440), (b,c,440), (c,a,440)]`
-- `vm_pair_min = [(a,n,210), (b,n,210), (c,n,210), (a,b,360), (b,c,360), (c,a,360)]`
+- `vm_pair_ub = [(a,n,250), (b,n,250), (c,n,250), (a,b,440), (b,c,440), (c,a,440)]`
+- `vm_pair_lb = [(a,n,210), (b,n,210), (c,n,210), (a,b,360), (b,c,360), (c,a,360)]`
 
 If terminal `4` is grounding through an impedance `Z=1+j2`, we write
 
@@ -100,23 +100,23 @@ A 4-phase system `[a,b,c,d]` is not well-defined; should there be phase-to-phase
 
 In order to avoid all of this confusion, we introduce this component, which is at most 3-phase, `|phases|<=3`, and which specifies all bounds symmetrically. For example,
 
-- `phases=[1,2,3], vm_pp_max=440` implies |U1-U2|, |U2-U3|, |U1-U3| <= 440
-- `phases=[1,2], vm_pn_max=440` implies |U1-U2| <= 440
+- `phases=[1,2,3], vm_pp_ub=440` implies |U1-U2|, |U2-U3|, |U1-U3| <= 440
+- `phases=[1,2], vm_pn_ub=440` implies |U1-U2| <= 440
 
 This keeps the user from specifying things that do not make sense. This type of bus would suffice for most of the use cases.
 
 Instead of defining the bounds directly, they can be specified through an associated voltagezone.
 
-| Name           | Default | Type   | Units | Description                                               |
-| -------------- | ------- | ------ | ----- | --------------------------------------------------------- |
-| `phases`       | `[1,2,3]`     | Vector{Any}  |       | Identifies the terminal that represents the neutral conductor |
-| `neutral`      | `4`     | `Any`  |       | Identifies the terminal that represents the neutral conductor |
-| `voltagezone`  |         | `Any`  |       | (Optional) id of an associated voltage zone               |
-| `vm_pn_min`    |         | `Real` |       | Minimum phase-to-neutral voltage magnitude for all phases |
-| `vm_pn_max`    |         | `Real` |       | Maximum phase-to-neutral voltage magnitude for all phases |
-| `vm_pp_min`    |         | `Real` |       | Minimum phase-to-phase voltage magnitude for all phases   |
-| `vm_pp_max`    |         | `Real` |       | Maximum phase-to-phase voltage magnitude for all phases   |
-| `vm_ng_rating` |         | `Real` |       | Maximum neutral-to-ground voltage magnitude               |
+| Name          | Default   | Type        | Units | Required | Description                                                   |
+| ------------- | --------- | ----------- | ----- | -------- | ------------------------------------------------------------- |
+| `phases`      | `[1,2,3]` | Vector{Any} |       |          | Identifies the terminal that represents the neutral conductor |
+| `neutral`     | `4`       | `Any`       |       |          | Identifies the terminal that represents the neutral conductor |
+| `voltagezone` |           | `Any`       |       |          | id of an associated voltage zone                              |
+| `vm_pn_lb`    |           | `Real`      |       |          | Minimum phase-to-neutral voltage magnitude for all phases     |
+| `vm_pn_ub`    |           | `Real`      |       |          | Maximum phase-to-neutral voltage magnitude for all phases     |
+| `vm_pp_lb`    |           | `Real`      |       |          | Minimum phase-to-phase voltage magnitude for all phases       |
+| `vm_pp_ub`    |           | `Real`      |       |          | Maximum phase-to-phase voltage magnitude for all phases       |
+| `vm_ng_ub`    |           | `Real`      |       |          | Maximum neutral-to-ground voltage magnitude                   |
 
 ## Edge Objects
 
@@ -126,25 +126,29 @@ These objects represent edges on the power grid and therefore require `f_bus` an
 
 This is a pi-model branch. When a `linecode` is given, and any of `rs`, `xs`, `b_fr`, `b_to`, `g_fr` or `g_to` are specified, any of those overwrite the values on the linecode.
 
-| Name            | Default | Type           | Units            | Description                                                                |
-| --------------- | ------- | -------------- | ---------------- | -------------------------------------------------------------------------- |
-| `f_bus`         |         | `Any`          |                  | id of from-side bus connection                                             |
-| `t_bus`         |         | `Any`          |                  | id of to-side bus connection                                               |
-| `f_connections` |         | `Vector{Any}`  |                  | Indicates for each conductor, to which terminal of the `f_bus` it connects |
-| `t_connections` |         | `Vector{Any}`  |                  | Indicates for each conductor, to which terminal of the `t_bus` it connects |
-| `linecode`      |         | `Any`          |                  | (Optional) id of an associated linecode                                    |
-| `rs`            |         | `Matrix{Real}` | ohm/meter        | Series resistance matrix, `size=(nconductors,nconductors)`                 |
-| `xs`            |         | `Matrix{Real}` | ohm/meter        | Series reactance matrix, `size=(nconductors,nconductors)`                  |
-| `g_fr`          |         | `Matrix{Real}` | siemens/meter/Hz | From-side conductance, `size=(nconductors,nconductors)`                    |
-| `b_fr`          |         | `Matrix{Real}` | siemens/meter/Hz | From-side susceptance, `size=(nconductors,nconductors)`                    |
-| `g_to`          |         | `Matrix{Real}` | siemens/meter/Hz | To-side conductance, `size=(nconductors,nconductors)`                      |
-| `b_to`          |         | `Matrix{Real}` | siemens/meter/Hz | To-side susceptance, `size=(nconductors,nconductors)`                      |
-| `length`        | `1.0`   | `Real`         | meter            | Length of the line                                                         |
-| `c_rating`      |         | `Vector{Real}` | amp              | Symmetrically applicable current rating, `size=nconductors`                |
-| `s_rating`      |         | `Vector{Real}` | watt             | Symmetrically applicable power rating, `size=nconductors`                  |
-| `status`        | `1`     | `Bool`         |                  | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
+| Name            | Default | Type           | Units            | Required     | Description                                                                |
+| --------------- | ------- | -------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
+| `f_bus`         |         | `Any`          |                  | always       | id of from-side bus connection                                             |
+| `t_bus`         |         | `Any`          |                  | always       | id of to-side bus connection                                               |
+| `f_connections` |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `f_bus` it connects |
+| `t_connections` |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `t_bus` it connects |
+| `linecode`      |         | `Any`          |                  | `!rs && !xs` | id of an associated linecode                                               |
+| `rs`            |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series resistance matrix, `size=(nconductors,nconductors)`                 |
+| `xs`            |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series reactance matrix, `size=(nconductors,nconductors)`                  |
+| `g_fr`          |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side conductance, `size=(nconductors,nconductors)`                    |
+| `b_fr`          |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side susceptance, `size=(nconductors,nconductors)`                    |
+| `g_to`          |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side conductance, `size=(nconductors,nconductors)`                      |
+| `b_to`          |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side susceptance, `size=(nconductors,nconductors)`                      |
+| `length`        | `1.0`   | `Real`         | meter            |              | Length of the line                                                         |
+| `cm_ub`         |         | `Vector{Real}` | amp              | opf          | Symmetrically applicable current rating, `size=nconductors`                |
+| `sm_ub`         |         | `Vector{Real}` | watt             | opf          | Symmetrically applicable power rating, `size=nconductors`                  |
+| `pl_fr`         |         | `Vector{Real}` | watt             |              | Present active power flow on the from-side                                 |
+| `ql_fr`         |         | `Vector{Real}` | watt             |              | Present reactive power flow on the from-side                               |
+| `pl_to`         |         | `Vector{Real}` | watt             |              | Present active power flow on the to-side                                   |
+| `ql_to`         |         | `Vector{Real}` | watt             |              | Present reactive power flow on the to-side                                 |
+| `status`        | `1`     | `Bool`         |                  | always       | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
 
-- which takes presidence, `c_rating` or `s_rating` if both are specified?
+- which takes presidence, `cm_ub` or `sm_ub` if both are specified?
 
 Add example for linecodes/lines off different size (conductors)
 
@@ -152,66 +156,68 @@ Add example for linecodes/lines off different size (conductors)
 
 These are n-winding (`nwinding`), n-phase (`nphase`), lossy transformers. Note that most properties are now Vectors (or Vectors of Vectors), indexed over the windings.
 
-| Name             | Default                                | Type                   | Units         | Description                                                                                                    |
-| ---------------- | -------------------------------------- | ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- |
-|                  | `buses`                                |                        | `Vector{Any}` |                                                                                                                | List of bus for each winding, `size=nwindings` |
-| `connections`    |                                        | `Vector{Vector{Any}}`  |               | List of connection for each winding, `size=((nconductors), nwindings)`                                         |
-| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |               | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
-| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm           | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
-| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm           | List of the winding resistance for each winding                                                                |
-| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |               | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
-| `tm_max`         |                                        | `Vector{Vector{Real}}` |               | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
-| `tm_min`         |                                        | `Vector{Vector{Real}}` |               | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
-| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |               | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
-| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |               | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
-| `status`         | `1`                                    | `Bool`                 |               | `1` or `0`. Indicates if component is enabled or disabled, respectively                                        |
+| Name             | Default                                | Type                   | Units | Required                           | Description                                                                                                    |
+| ---------------- | -------------------------------------- | ---------------------- | ----- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `buses`          |                                        | `Vector{Any}`          |       | `!f_bus && !t_bus`                 | List of bus for each winding, `size=nwindings`                                                                 |
+| `connections`    |                                        | `Vector{Vector{Any}}`  |       | `!f_connections && !t_connections` | List of connection for each winding, `size=((nconductors), nwindings)`                                         |
+| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       | always                             | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
+| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |                                    | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
+| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |                                    | List of the winding resistance for each winding                                                                |
+| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |                                    | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
+| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
+| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       | opf                                | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
+| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |                                    | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
+| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |                                    | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
+| `status`         | `1`                                    | `Bool`                 |       | always                             | `1` or `0`. Indicates if component is enabled or disabled, respectively                                        |
 
 #### Assymetric, Lossless, Two-Winding (AL2W) Transformers
 
 Special case of the Generic transformer. These are transformers are assymetric (A), lossless (L) and two-winding (2W). Assymetric refers to the fact that the secondary is always has a `wye` configuration, whilst the primary can be `delta`. The table below indicates alternate, more simple ways to specify the special case of an AL2W Transformer. `xsc` and `rs` cannot be specified for an AL2W transformer.
 
-| Name            | Default               | Type           | Units | Description                                                                                                        |
-| --------------- | --------------------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------ |
-| `f_bus`         |                       | `Any`          |       | (Optional) Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                   |
-| `t_bus`         |                       | `Any`          |       | (Optional) Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                  |
-| `f_connections` |                       | `Vector{Any}`  |       | (Optional) Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
-| `t_connections` |                       | `Vector{Any}`  |       | (Optional) Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
-| `configuration` | `"wye"`               | `String`       |       | (Optional) `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"` |
-| `tm_nom`        | `1.0`                 | `Real`         |       | Nominal tap ratio for the transformer (multiplier)                                                                 |
-| `tm_max`        |                       | `Vector{Real}` |       | Maximum tap ratio for each phase (base=`tm_nom`)                                                                   |
-| `tm_min`        |                       | `Vector{Real}` |       | Minimum tap ratio for each phase (base=`tm_nom`)                                                                   |
-| `tm_set`        | `fill(1.0, nphases)`  | `Vector{Real}` |       | Set tap ratio for each phase (base=`tm_nom`)                                                                       |
-| `tm_fix`        | `fill(true, nphases)` | `Vector{Real}` |       | Indicates for each phase whether the tap ratio is fixed                                                            |
+| Name            | Default               | Type           | Units | Required       | Description                                                                                             |
+| --------------- | --------------------- | -------------- | ----- | -------------- | ------------------------------------------------------------------------------------------------------- |
+| `f_bus`         |                       | `Any`          |       | `!buses`       | Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                   |
+| `t_bus`         |                       | `Any`          |       | `!buses`       | Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                  |
+| `f_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
+| `t_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
+| `configuration` | `"wye"`               | `String`       |       |                | `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"` |
+| `tm_nom`        | `1.0`                 | `Real`         |       |                | Nominal tap ratio for the transformer (multiplier)                                                      |
+| `tm_ub`         |                       | `Vector{Real}` |       | opf            | Maximum tap ratio for each phase (base=`tm_nom`)                                                        |
+| `tm_lb`         |                       | `Vector{Real}` |       | opf            | Minimum tap ratio for each phase (base=`tm_nom`)                                                        |
+| `tm_set`        | `fill(1.0, nphases)`  | `Vector{Real}` |       |                | Set tap ratio for each phase (base=`tm_nom`)                                                            |
+| `tm_fix`        | `fill(true, nphases)` | `Vector{Real}` |       |                | Indicates for each phase whether the tap ratio is fixed                                                 |
 
 ### Switches (`switch`)
 
 Switches without any of `rs`, `xs`, `g_fr`, `b_fr`, `g_to`, `b_to` defined are assumed to be lossless. If lossy parameters are defined, `switch` objects will be decomposed into virtual `branch` & `bus`, and an ideal `switch`.
 
-| Name            | Default    | Type           | Units   | Description                                                                |
-| --------------- | ---------- | -------------- | ------- | -------------------------------------------------------------------------- |
-| `f_bus`         |            | `Any`          |         | id of from-side bus connection                                             |
-| `t_bus`         |            | `Any`          |         | id of to-side bus connection                                               |
-| `f_connections` |            | `Vector{Any}`  |         | Indicates for each conductor, to which terminal of the `f_bus` it connects |
-| `t_connections` |            | `Vector{Any}`  |         | Indicates for each conductor, to which terminal of the `t_bus` it connects |
-| `c_rating`      |            | `Vector{Real}` | amp     | Symmetrically applicable current rating                                    |
-| `s_rating`      |            | `Vector{Real}` | watt    | Symmetrically applicable power rating                                      |
-| `rs`            |            | `Matrix{Real}` | ohm     | (Optional) Series resistance matrix, `size=(nphases,nphases)`              |
-| `xs`            |            | `Matrix{Real}` | ohm     | (Optional) Series reactance matrix, `size=(nphases,nphases)`               |
-| `g_fr`          |            | `Matrix{Real}` | siemens | (Optional) From-side conductance, `size=(nphases,nphases)`,                |
-| `b_fr`          |            | `Matrix{Real}` | siemens | (Optional) From-side susceptance, `size=(nphases,nphases)`                 |
-| `g_to`          |            | `Matrix{Real}` | siemens | (Optional) To-side conductance, `size=(nphases,nphases)`                   |
-| `b_to`          |            | `Matrix{Real}` | siemens | (Optional) To-side susceptance, `size=(nphases,nphases)`                   |
-| `state`         | `"closed"` | `String`       |         | `"open"` or `"closed"`, to indicate initial/current state of switch        |
-| `status`        | `1`        | `Bool`         |         | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
+| Name            | Default | Type           | Units   | Required | Description                                                                |
+| --------------- | ------- | -------------- | ------- | -------- | -------------------------------------------------------------------------- |
+| `f_bus`         |         | `Any`          |         | always   | id of from-side bus connection                                             |
+| `t_bus`         |         | `Any`          |         | always   | id of to-side bus connection                                               |
+| `f_connections` |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `f_bus` it connects |
+| `t_connections` |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `t_bus` it connects |
+| `cm_ub`         |         | `Vector{Real}` | amp     | opf      | Symmetrically applicable current rating                                    |
+| `sm_ub`         |         | `Vector{Real}` | watt    | opf      | Symmetrically applicable power rating                                      |
+| `rs`            |         | `Matrix{Real}` | ohm     |          | Series resistance matrix, `size=(nphases,nphases)`                         |
+| `xs`            |         | `Matrix{Real}` | ohm     |          | Series reactance matrix, `size=(nphases,nphases)`                          |
+| `g_fr`          |         | `Matrix{Real}` | siemens |          | From-side conductance, `size=(nphases,nphases)`,                           |
+| `b_fr`          |         | `Matrix{Real}` | siemens |          | From-side susceptance, `size=(nphases,nphases)`                            |
+| `g_to`          |         | `Matrix{Real}` | siemens |          | To-side conductance, `size=(nphases,nphases)`                              |
+| `b_to`          |         | `Matrix{Real}` | siemens |          | To-side susceptance, `size=(nphases,nphases)`                              |
+| `psw`           |         | `Vector{Real}` | watt    |          | Present value of active power flow across the switch                       |
+| `qsw`           |         | `Vector{Real}` | var     |          | Present value of reactive power flow across the switch                     |
+| `state`         | `1`     | `Int`          |         | always   | `1`: closed or `0`: open, to indicate state of switch                      |
+| `status`        | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
 
 #### Fuses (`fuse`)
 
 Special Case of switch, with its own separate component category for easier tracking. Shares the fields of switch, with these additions.
 
-| Name                    | Default | Type     | Units | Description                                                                        |
-| ----------------------- | ------- | -------- | ----- | ---------------------------------------------------------------------------------- |
-| `fuse_curve`            |         | `String` |       | (Optional) id of `curve` object that specifies the fuse blowing condition          |
-| `minimum_melting_curve` |         | `String` |       | (Optional) id of `curve` that specifies the minimum melting conditions of the fuse |
+| Name                    | Default | Type     | Units | Required | Description                                                             |
+| ----------------------- | ------- | -------- | ----- | -------- | ----------------------------------------------------------------------- |
+| `fuse_curve`            |         | `String` |       |          | id of `curve` object that specifies the fuse blowing condition          |
+| `minimum_melting_curve` |         | `String` |       |          | id of `curve` that specifies the minimum melting conditions of the fuse |
 
 ### Line Reactors (`line_reactor`)
 
@@ -227,26 +233,26 @@ These are objects that have single bus connections. Every object will have at le
 
 ### Shunts (`shunt`)
 
-| Name            | Default | Type           | Units   | Description                                                             |
-| --------------- | ------- | -------------- | ------- | ----------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |         | id of bus connection                                                    |
-| `connections`   |         | `Vector{Any}`  |         | Ordered list of connected conductors                                    |
-| `configuration` | `"wye"` | `String`       |         | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `g`             |         | `Matrix{Real}` | siemens | Conductance, `size=(nphases,nphases)`                                   |
-| `b`             |         | `Matrix{Real}` | siemens | Susceptance, `size=(nphases,nphases)`                                   |
-| `status`        | `1`     | `Bool`         |         | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name            | Default | Type           | Units   | Required | Description                                                             |
+| --------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------- |
+| `bus`           |         | `Any`          |         | always   | id of bus connection                                                    |
+| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                    |
+| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
+| `gs`            |         | `Matrix{Real}` | siemens | always   | Conductance, `size=(nphases,nphases)`                                   |
+| `bs`            |         | `Matrix{Real}` | siemens | always   | Susceptance, `size=(nphases,nphases)`                                   |
+| `status`        | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
 
 #### Shunt Capacitors (`shunt_capacitor`)
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
-| Name            | Default | Type           | Units   | Description                                                                                          |
-| --------------- | ------- | -------------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |         | id of bus connection                                                                                 |
-| `connections`   |         | `Vector{Any}`  |         | Ordered list of connected conductors, `size=nconductors`                                             |
-| `configuration` | `"wye"` | `String`       |         | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only |
-| `b`             |         | `Vector{Real}` | siemens | Conductance, `size=(nconductors,nconductors)`                                                        |
-| `vnom`          |         | `Real`         | volt    | Nominal voltage (multiplier)                                                                         |
+| Name            | Default | Type           | Units   | Required | Description                                                                                          |
+| --------------- | ------- | -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `bus`           |         | `Any`          |         | always   | id of bus connection                                                                                 |
+| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                             |
+| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only |
+| `bs`            |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                        |
+| `vnom`          |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                         |
 
 Give some examples
 
@@ -254,65 +260,98 @@ Give some examples
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
+| Name            | Default | Type           | Units   | Required | Description                                                                                          |
+| --------------- | ------- | -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `bus`           |         | `Any`          |         | always   | id of bus connection                                                                                 |
+| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                             |
+| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only |
+| `bs`            |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                        |
+| `vnom`          |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                         |
+
 ### Loads (`load`)
 
-| Name            | Default            | Type           | Units | Description                                                                                                                             |
-| --------------- | ------------------ | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `bus`           |                    | `Any`          |       | id of bus connection                                                                                                                    |
-| `connections`   |                    | `Vector{Any}`  |       | Ordered list of connected conductors                                                                                                    |
-| `configuration` | `"wye"`            | `String`       |       | `"wye"` or "`delta`". If `"wye"`, `connections[end]=neutral`                                                                            |
-| `model`         | `"constant_power"` | `String`       |       | `"constant_power"`, `"constant_impedance"`, `"constant_current"`, `"exponential"`, or `"zip"`. Indicates the type of voltage-dependency |
-| `pd_ref`        |                    | `Vector{Real}` | watt  | Real load, `size=nphases`                                                                                                               |
-| `qd_ref`        |                    | `Vector{Real}` | var   | Reactive load, `size=nphases`                                                                                                           |
-| `vnom`          |                    | `Real`         | volt  | Nominal voltage (multiplier)                                                                                                            |
-| `status`        | `1`                | `Bool`         |       | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                 |
+| Name            | Default            | Type           | Units | Required | Description                                                                                                                             |
+| --------------- | ------------------ | -------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `bus`           |                    | `Any`          |       | always   | id of bus connection                                                                                                                    |
+| `connections`   |                    | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                                                    |
+| `configuration` | `"wye"`            | `String`       |       | always   | `"wye"` or "`delta`". If `"wye"`, `connections[end]=neutral`                                                                            |
+| `model`         | `"constant_power"` | `String`       |       | always   | `"constant_power"`, `"constant_impedance"`, `"constant_current"`, `"exponential"`, or `"zip"`. Indicates the type of voltage-dependency |
+| `pd_nom`        |                    | `Vector{Real}` | watt  | always   | Nominal active load, with respect to `vnom`, `size=nphases`                                                                             |
+| `qd_nom`        |                    | `Vector{Real}` | var   | always   | Nominal reactive load, with respect to `vnom`, `size=nphases`                                                                           |
+| `vnom`          |                    | `Real`         | volt  | always   | Nominal voltage (multiplier)                                                                                                            |
+| `status`        | `1`                | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                 |
 
 #### `model="exponential"`
 
-| Name    | Default | Type   | Units | Description |
-| ------- | ------- | ------ | ----- | ----------- |
-| `exp_p` |         | `Real` |       |             |
-| `exp_q` |         | `Real` |       |             |
+| Name     | Default | Type   | Units | Required               | Description |
+| -------- | ------- | ------ | ----- | ---------------------- | ----------- |
+| `pd_exp` |         | `Real` |       | `model=="exponential"` |             |
+| `qd_exp` |         | `Real` |       | `model=="exponential"` |             |
 
 #### `model="zip"`
 
-| Name        | Default | Type   | Units | Description |
-| ----------- | ------- | ------ | ----- | ----------- |
-| `coeff_z_p` |         | `Real` |       |             |
-| `coeff_i_p` |         | `Real` |       |             |
-| `coeff_p_p` |         | `Real` |       |             |
-| `coeff_z_q` |         | `Real` |       |             |
-| `coeff_i_q` |         | `Real` |       |             |
-| `coeff_p_q` |         | `Real` |       |             |
+| Name       | Default | Type   | Units | Required       | Description |
+| ---------- | ------- | ------ | ----- | -------------- | ----------- |
+| `pd_nom_z` |         | `Real` |       | `model=="zip"` |             |
+| `pd_nom_i` |         | `Real` |       | `model=="zip"` |             |
+| `pd_nom_p` |         | `Real` |       | `model=="zip"` |             |
+| `qd_nom_z` |         | `Real` |       | `model=="zip"` |             |
+| `qd_nom_i` |         | `Real` |       | `model=="zip"` |             |
+| `qd_nom_p` |         | `Real` |       | `model=="zip"` |             |
 
 ### Generators or Induction Machines or Asychronous Machines? (`generator` or `asychronous_machine` or `induction_machine`?)
 
-| Name            | Default | Type           | Units | Description                                                             |
-| --------------- | ------- | -------------- | ----- | ----------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |       | id of bus connection                                                    |
-| `connections`   |         | `Vector{Any}`  |       | Ordered list of connected conductors                                    |
-| `configuration` | `"wye"` | `String`       |       | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `pg_min`        |         | `Vector{Real}` | watt  | Lower bound on active power generation per phase, `size=nphases`        |
-| `pg_max`        |         | `Vector{Real}` | watt  | Upper bound on active power generation per phase, `size=nphases`        |
-| `qg_min`        |         | `Vector{Real}` | var   | Lower bound on reactive power generation per phase, `size=nphases`      |
-| `qg_max`        |         | `Vector{Real}` | var   | Upper bound on reactive power generation per phase, `size=nphases`      |
-| `status`        | `1`     | `Bool`         |       | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name            | Default | Type           | Units | Required | Description                                                             |
+| --------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------- |
+| `bus`           |         | `Any`          |       | always   | id of bus connection                                                    |
+| `connections`   |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                    |
+| `configuration` | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
+| `pg_lb`         |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`        |
+| `pg_ub`         |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`        |
+| `qg_lb`         |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`      |
+| `qg_ub`         |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`      |
+| `pg`            |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`               |
+| `qg`            |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`             |
+| `status`        | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
 
 #### Cost Model
 
 The generator cost model is specified by the following fields.
 
-| Name              | Default           | Type           | Units | Description           |
-| ----------------- | ----------------- | -------------- | ----- | --------------------- |
-| `cost_model`      | `2`               | `Int`          |       |                       |
-| `startup`         | `0.0`             | `Real`         | $     | Startup cost          |
-| `shutdown`        | `0.0`             | `Real`         | $     | Shutdown cost         |
-| `ncost_terms`     | `3`               | `Int`          |       | Number of cost terms  |
-| `cost_polynomial` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | Cost model polynomial |
+| Name                 | Default           | Type           | Units | Required | Description                                               |
+| -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
+| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
+| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
+| `startup`            | `0.0`             | `Real`         | $     | opf      | Startup cost                                              |
+| `shutdown`           | `0.0`             | `Real`         | $     | opf      | Shutdown cost                                             |
 
 ### Photovoltaic Systems (`solar`)
 
-TODO
+| Name            | Default | Type           | Units | Required | Description                                                             |
+| --------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------- |
+| `bus`           |         | `Any`          |       | always   | id of bus connection                                                    |
+| `connections`   |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                    |
+| `configuration` | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
+| `pg_lb`         |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`        |
+| `pg_ub`         |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`        |
+| `qg_lb`         |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`      |
+| `qg_ub`         |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`      |
+| `pg`            |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`               |
+| `qg`            |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`             |
+| `status`        | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+
+#### Irradiation
+
+#### Cost Model
+
+The cost model for a photovoltaic system currently matches that of generators.
+
+| Name                 | Default           | Type           | Units | Required | Description                                               |
+| -------------------- | ----------------- | -------------- | ----- | -------- | --------------------------------------------------------- |
+| `cost_pg_model`      | `2`               | `Int`          |       | opf      | Cost model type, `1` = piecewise-linear, `2` = polynomial |
+| `cost_pg_parameters` | `[0.0, 1.0, 0.0]` | `Vector{Real}` | $/MVA | opf      | Cost model polynomial                                     |
+| `startup`            | `0.0`             | `Real`         | $     | opf      | Startup cost                                              |
+| `shutdown`           | `0.0`             | `Real`         | $     | opf      | Shutdown cost                                             |
 
 ### Wind Turbine Systems (`wind`)
 
@@ -324,41 +363,43 @@ A storage object is a flexible component that can represent a variety of energy 
 
 - How to include the inverter model for this? Similar issue as for a PV generator
 
-| Name                   | Default | Type           | Units   | Description                                                             |
-| ---------------------- | ------- | -------------- | ------- | ----------------------------------------------------------------------- |
-| `bus`                  |         | `Any`          |         | id of bus connection                                                    |
-| `connections`          |         | `Vector{Any}`  |         | Ordered list of connected conductors                                    |
-| `configuration`        | `"wye"` | `String`       |         | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `energy`               |         | `Real`         | watt-hr | Stored energy                                                           |
-| `energy_rating`        |         | `Real`         |         |                                                                         |
-| `charge_rating`        |         | `Real`         |         |                                                                         |
-| `discharge_rating`     |         | `Real`         |         |                                                                         |
-| `s_rating`             |         | `Vector{Real}` | watt    | Power rating, `size=nphases`                                            |
-| `c_rating`             |         | `Vector{Real}` | amp     | Current rating, `size=nphases`                                          |
-| `charge_efficiency`    |         | `Real`         |         |                                                                         |
-| `discharge_efficiency` |         | `Real`         |         |                                                                         |
-| `qmax`                 |         | `Vector{Real}` |         | Maximum reactive power, `size=nphases`                                  |
-| `qmin`                 |         | `Vector{Real}` |         | Minimum reactive power, `size=nphases`                                  |
-| `r`                    |         | `Vector{Real}` | ohm     |                                                                         |
-| `x`                    |         | `Vector{Real}` | ohm     |                                                                         |
-| `p_loss`               |         | `Real`         |         | Total active power standby loss                                         |
-| `q_loss`               |         | `Real`         |         | Total reactive power standby loss                                       |
-| `status`               | `1`     | `Bool`         |         | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name                   | Default | Type           | Units   | Required | Description                                                             |
+| ---------------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------- |
+| `bus`                  |         | `Any`          |         | always   | id of bus connection                                                    |
+| `connections`          |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                    |
+| `configuration`        | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
+| `energy`               |         | `Real`         | watt-hr | always   | Stored energy                                                           |
+| `energy_ub`            |         | `Real`         |         | opf      |                                                                         |
+| `charge_ub`            |         | `Real`         |         | opf      |                                                                         |
+| `discharge_ub`         |         | `Real`         |         | opf      |                                                                         |
+| `sm_ub`                |         | `Vector{Real}` | watt    | opf      | Power rating, `size=nphases`                                            |
+| `cm_ub`                |         | `Vector{Real}` | amp     | opf      | Current rating, `size=nphases`                                          |
+| `charge_efficiency`    |         | `Real`         |         | always   |                                                                         |
+| `discharge_efficiency` |         | `Real`         |         | always   |                                                                         |
+| `qs_ub`                |         | `Vector{Real}` |         | opf      | Maximum reactive power injection, `size=nphases`                        |
+| `qs_lb`                |         | `Vector{Real}` |         | opf      | Minimum reactive power injection, `size=nphases`                        |
+| `rs`                   |         | `Vector{Real}` | ohm     | always   |                                                                         |
+| `xs`                   |         | `Vector{Real}` | ohm     | always   |                                                                         |
+| `pex`                  |         | `Real`         |         | always   | Total active power standby exogenous flow (loss)                        |
+| `qex`                  |         | `Real`         |         | always   | Total reactive power standby exogenous flow (loss)                      |
+| `ps`                   |         | `Vector{Real}` | watt    |          | Present active power injection                                          |
+| `qs`                   |         | `Vector{Real}` | var     |          | Present reactive power injection                                        |
+| `status`               | `1`     | `Bool`         |         | opf      | `1` or `0`. Indicates if component is enabled or disabled, respectively |
 
 ### Voltage Sources (`voltage_source`)
 
 A voltage source is a source of power at a set voltage magnitude and angle connected to a slack bus. If `rs` or `xs` are not specified, the voltage source is assumed to be lossless, otherwise virtual `branch` and `bus` will be created in the mathematical model to represent the internal losses of the voltage source.
 
-| Name            | Default         | Type           | Units  | Description                                                                               |
-| --------------- | --------------- | -------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `bus`           |                 | `Any`          |        | id of bus connection                                                                      |
-| `connections`   |                 | `Vector{Any}`  |        | Ordered list of connected conductors                                                      |
-| `configuration` | `"wye"`         | `String`       |        | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                              |
-| `vm`            | `ones(nphases)` | `Vector{Real}` | volt   | Voltage magnitude set at slack bus                                                        |
-| `va`            | `0.0`           | `Real`         | degree | (Optional) Voltage angle offset at slack bus                                              |
-| `rs`            |                 | `Matrix{Real}` | ohm    | (Optional) Internal series resistance of voltage source, `size=(nconductors,nconductors)` |
-| `xs`            |                 | `Matrix{Real}` | ohm    | (Optional) Internal series reactance of voltage soure, `size=(nconductors,nconductors)`   |
-| `status`        | `1`             | `Bool`         |        | `1` or `0`. Indicates if component is enabled or disabled, respectively                   |
+| Name            | Default         | Type           | Units  | Required | Description                                                                    |
+| --------------- | --------------- | -------------- | ------ | -------- | ------------------------------------------------------------------------------ |
+| `bus`           |                 | `Any`          |        | always   | id of bus connection                                                           |
+| `connections`   |                 | `Vector{Any}`  |        | always   | Ordered list of connected conductors                                           |
+| `configuration` | `"wye"`         | `String`       |        | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                   |
+| `vm`            | `ones(nphases)` | `Vector{Real}` | volt   | always   | Voltage magnitude set at slack bus                                             |
+| `va`            | `0.0`           | `Real`         | degree |          | Voltage angle offset at slack bus                                              |
+| `rs`            |                 | `Matrix{Real}` | ohm    |          | Internal series resistance of voltage source, `size=(nconductors,nconductors)` |
+| `xs`            |                 | `Matrix{Real}` | ohm    |          | Internal series reactance of voltage soure, `size=(nconductors,nconductors)`   |
+| `status`        | `1`             | `Bool`         |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively        |
 
 ## Data Objects (codes, curves, shapes)
 
@@ -368,60 +409,60 @@ These objects are referenced by node and edge objects, but are not part of the n
 
 Linecodes are easy ways to specify properties common to multiple lines.
 
-- Should the linecode also include a `c_rating` and `s_rating`? I think not. `c_rating` yes, `s_rating` does not make sense. `s_rating`, if desired, should be specified at the line level
+- Should the linecode also include a `cm_ub` and `sm_ub`? I think not. `cm_ub` yes, `sm_ub` does not make sense. `sm_ub`, if desired, should be specified at the line level
 - Does `cmatrix` makes more sense than `g_fr, b_fr, g_to, b_to` when parametrized per length? No, enforce symmetry. If needed place a shunt or inject at low-level.
 
-| Name     | Default | Type           | Units            | Description                                                             |
-| -------- | ------- | -------------- | ---------------- | ----------------------------------------------------------------------- |
-| `rs`     |         | `Matrix{Real}` | ohm/meter        | Series resistance, `size=(nconductors,nconductors)`                     |
-| `xs`     |         | `Matrix{Real}` | ohm/meter        | Series reactance, `size=(nconductors,nconductors)`                      |
-| `g_fr`   |         | `Matrix{Real}` | siemens/meter/Hz | From-side conductance, `size=(nconductors,nconductors)`                 |
-| `b_fr`   |         | `Matrix{Real}` | siemens/meter/Hz | From-side susceptance, `size=(nconductors,nconductors)`                 |
-| `g_to`   |         | `Matrix{Real}` | siemens/meter/Hz | To-side conductance, `size=(nconductors,nconductors)`                   |
-| `b_to`   |         | `Matrix{Real}` | siemens/meter/Hz | To-side susceptance, `size=(nconductors,nconductors)`                   |
-| `c_rating`   |         | `Vector{Real}` | ampere | maximum current per conductor, symmetrically applicable                   |
+| Name    | Default | Type           | Units            | Required | Description                                             |
+| ------- | ------- | -------------- | ---------------- | -------- | ------------------------------------------------------- |
+| `rs`    |         | `Matrix{Real}` | ohm/meter        |          | Series resistance, `size=(nconductors,nconductors)`     |
+| `xs`    |         | `Matrix{Real}` | ohm/meter        |          | Series reactance, `size=(nconductors,nconductors)`      |
+| `g_fr`  |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side conductance, `size=(nconductors,nconductors)` |
+| `b_fr`  |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side susceptance, `size=(nconductors,nconductors)` |
+| `g_to`  |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side conductance, `size=(nconductors,nconductors)`   |
+| `b_to`  |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side susceptance, `size=(nconductors,nconductors)`   |
+| `cm_ub` |         | `Vector{Real}` | ampere           |          | maximum current per conductor, symmetrically applicable |
 
 ### Transformer Codes (`xfmrcode`)
 
 Transformer codes are easy ways to specify properties common to multiple transformers
 
-| Name             | Default                                | Type                   | Units | Description                                                                                                    |
-| ---------------- | -------------------------------------- | ---------------------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
-| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
-| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   | List of the winding resistance for each winding                                                                |
-| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
-| `tm_max`         |                                        | `Vector{Vector{Real}}` |       | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
-| `tm_min`         |                                        | `Vector{Vector{Real}}` |       | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
-| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
-| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
+| Name             | Default                                | Type                   | Units | Required | Description                                                                                                    |
+| ---------------- | -------------------------------------- | ---------------------- | ----- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `configurations` | `fill("wye", nwindings)`               | `Vector{String}`       |       |          | `"wye"` or `"delta"`. List of configuration for each winding, `size=nwindings`                                 |
+| `xsc`            | `[0.0]`                                | `Vector{Real}`         | ohm   |          | List of short-circuit reactances between each pair of windings; enter as a list of the upper-triangle elements |
+| `rs`             | `zeros(nwindings)`                     | `Vector{Real}`         | ohm   |          | List of the winding resistance for each winding                                                                |
+| `tm_nom`         | `ones(nwindings)`                      | `Vector{Real}`         |       |          | Nominal tap ratio for the transformer, `size=nwindings` (multiplier)                                           |
+| `tm_ub`          |                                        | `Vector{Vector{Real}}` |       |          | Maximum tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                    |
+| `tm_lb`          |                                        | `Vector{Vector{Real}}` |       |          | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
+| `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |          | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
+| `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |          | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
 
 ### Voltage Zones (`voltagezone`)
 
 Voltage zones are a convenient way to specify voltage bounds for a set of three-phase buses (ones with `phases`/`neutral` properties).
 
-| Name             | Default                                | Type                   | Units | Description                                                                                                    |
-| ---------------- | -------------------------------------- | ---------------------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| `vnom`         |         | `Real` |       | Nominal phase-to-neutral voltage |
-| `vm_pn_min`    |         | `Real` |       | Minimum phase-to-neutral voltage magnitude for all phases |
-| `vm_pn_max`    |         | `Real` |       | Maximum phase-to-neutral voltage magnitude for all phases |
-| `vm_pp_min`    |         | `Real` |       | Minimum phase-to-phase voltage magnitude for all phases   |
-| `vm_pp_max`    |         | `Real` |       | Maximum phase-to-phase voltage magnitude for all phases   |
-| `vm_ng_rating` |         | `Real` |       | Maximum neutral-to-ground voltage magnitude               |
+| Name       | Default | Type   | Units | Required | Description                                               |
+| ---------- | ------- | ------ | ----- | -------- | --------------------------------------------------------- |
+| `vnom`     |         | `Real` |       | always   | Nominal phase-to-neutral voltage                          |
+| `vm_pn_lb` |         | `Real` |       |          | Minimum phase-to-neutral voltage magnitude for all phases |
+| `vm_pn_ub` |         | `Real` |       |          | Maximum phase-to-neutral voltage magnitude for all phases |
+| `vm_pp_lb` |         | `Real` |       |          | Minimum phase-to-phase voltage magnitude for all phases   |
+| `vm_pp_ub` |         | `Real` |       |          | Maximum phase-to-phase voltage magnitude for all phases   |
+| `vm_ng_ub` |         | `Real` |       |          | Maximum neutral-to-ground voltage magnitude               |
+
 ### Curves (`curve`)
 
 Curve objects are functions f(x) that return single values for a given x. This is useful for several objects like `solar` power-temperature curves, or efficiency curves on various objects.
 
-| Name    | Default | Type     | Units | Description |
-| ------- | ------- | -------- | ----- | ----------- |
-| `curve` |         | Function |       |             |
+| Name    | Default | Type     | Units | Required | Description |
+| ------- | ------- | -------- | ----- | -------- | ----------- |
+| `curve` |         | Function |       | always   |             |
 
 ### Time Series (`time_series`)
 
 Time series objects are used to specify time series for _e.g._ load or generation forecasts.
 
-| Name         | Default | Type           | Units | Description                                                                                                                                                         |
-| ------------ | ------- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `time`       |         | `Vector{Real}` | hour  | Time points at which values are specified                                                                                                                           |
-| `multiplier` |         | `Vector{Real}` |       | Multipers at each time step given in `time`. If `useactual`, multipliers do not multiply original values, but replace them on the objects to which they are applied |
-| `use_actual` | `false` | `Bool`         |       | If `use_actual`, multiplier replaces values, instead of multiplying                                                                                                 |
+| Name         | Default | Type           | Units | Required | Description                                                                                                                                                         |
+| ------------ | ------- | -------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `time`       |         | `Vector{Real}` | hour  | always   | Time points at which values are specified                                                                                                                           |
+| `multiplier` |         | `Vector{Real}` |       | always   | Multipers at each time step given in `time`. If `useactual`, multipliers do not multiply original values, but replace them on the objects to which they are applied |

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -29,8 +29,6 @@ Each edge or node component (_i.e._ all those that are not data objects or buses
 
 Parameter values on components are expected to be specified in SI units by default (where applicable) in the engineering data model. Relevant expected units are noted in the sections below. Where units is listed as watt, real units will be watt * `v_var_scalar`. Where units are listed as volt/var, real units will be volt/var * `v_var_scalar`, and multiplied by `vnom`, where that value exists.
 
-TODO: Specify units on each component
-
 ## Root-Level Properties
 
 At the root level of the data structure, the following fields can be found.
@@ -225,11 +223,11 @@ Special Case of switch, with its own separate component category for easier trac
 
 ### Line Reactors (`line_reactor`)
 
-TODO
+Line reactors are _e.g._ inductors can can be used to protect against input power distruptions
 
 ### Series Capacitors (`series_capacitor`)
 
-TODO
+Series capacitors can be used to _e.g._ compensate inductance on lines
 
 ## Node Objects
 

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -23,7 +23,7 @@ Dict{String,Any}(
 )
 ```
 
-Valid component types are those that are documented in the sectios below. Each component object is identified by an `id`, which can be any immutable value, but `id` does not appear inside of the component dictionary, and only appears as keys to the component dictionaries under each component type.
+Valid component types are those that are documented in the sectios below. Each component object is identified by an `id`, which can be any immutable value (`id <: Any`), but `id` does not appear inside of the component dictionary, and only appears as keys to the component dictionaries under each component type.
 
 Each edge or node component (_i.e._ all those that are not data objects or buses), are expected to have `status` fields to specify whether the component is active or disabled, `bus` or `f_bus` and `t_bus`, to specify the buses that are connected to the component, and `connections` or `f_connections` and `t_connections`, to specify the terminals of the buses that are actively connected in an ordered list. Terminals/connections can be any immutable value, as can bus ids.
 

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -60,19 +60,20 @@ The data model below allows us to include buses of arbitrary many terminals (_i.
 - underground lines with multiple neutrals which are not joined at every bus;
 - distribution lines that carry several conventional lines in parallel (see for example the quad circuits in NEVTestCase).
 
-| Name         | Default     | Type            | Units  | Required | Description                                                             |
-| ------------ | ----------- | --------------- | ------ | -------- | ----------------------------------------------------------------------- |
-| `terminals`  | `[1,2,3,4]` | `Vector{Any}`   |        | always   | Terminals for which the bus has active connections                      |
-| `vm_lb`      |             | `Vector{Real}`  |        | opf      | Minimum conductor-to-ground voltage magnitude, `size=nphases`           |
-| `vm_ub`      |             | `Vector{Real}`  |        | opf      | Maximum conductor-to-ground voltage magnitude, `size=nphases`           |
-| `vm_pair_ub` |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                               |
-| `vm_pair_lb` |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                               |
-| `grounded`   | `[]`        | `Vector{Any}`   |        |          | List of terminals which are grounded                                    |
-| `rg`         | `[]`        | `Vector{Real}`  |        |          | Resistance of each defined grounding, `size=length(grounded)`           |
-| `xg`         | `[]`        | `Vector{Real}`  |        |          | Reactance of each defined grounding, `size=length(grounded)`            |
-| `vm`         |             | `Vector{Real}`  | volt   |          | Voltage magnitude at bus                                                |
-| `va`         |             | `Vector{Real}`  | degree |          | Voltage angle at bus                                                    |
-| `status`     | `1`         | `Bool`          |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name             | Default     | Type            | Units  | Required | Description                                                                                                 |
+| ---------------- | ----------- | --------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `terminals`      | `[1,2,3,4]` | `Vector{Any}`   |        | always   | Terminals for which the bus has active connections                                                          |
+| `vm_lb`          |             | `Vector{Real}`  |        | opf      | Minimum conductor-to-ground voltage magnitude, `size=nphases`                                               |
+| `vm_ub`          |             | `Vector{Real}`  |        | opf      | Maximum conductor-to-ground voltage magnitude, `size=nphases`                                               |
+| `vm_pair_ub`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,210)]` means \|U1-U2\|>210                                                                   |
+| `vm_pair_lb`     |             | `Vector{Tuple}` |        | opf      | _e.g._  `[(1,2,230)]` means \|U1-U2\|<230                                                                   |
+| `grounded`       | `[]`        | `Vector{Any}`   |        |          | List of terminals which are grounded                                                                        |
+| `rg`             | `[]`        | `Vector{Real}`  |        |          | Resistance of each defined grounding, `size=length(grounded)`                                               |
+| `xg`             | `[]`        | `Vector{Real}`  |        |          | Reactance of each defined grounding, `size=length(grounded)`                                                |
+| `vm`             |             | `Vector{Real}`  | volt   |          | Voltage magnitude at bus                                                                                    |
+| `va`             |             | `Vector{Real}`  | degree |          | Voltage angle at bus                                                                                        |
+| `status`         | `1`         | `Bool`          |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |             | `Any`           |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 The tricky part is how to encode bounds for these type of buses. The most general is defining a list of three-tuples. Take for example a typical bus in a three-phase, four-wire network, where `terminals=[a,b,c,n]`. Such a bus might have
 
@@ -126,27 +127,28 @@ These objects represent edges on the power grid and therefore require `f_bus` an
 
 This is a pi-model branch. When a `linecode` is given, and any of `rs`, `xs`, `b_fr`, `b_to`, `g_fr` or `g_to` are specified, any of those overwrite the values on the linecode.
 
-| Name            | Default | Type           | Units            | Required     | Description                                                                |
-| --------------- | ------- | -------------- | ---------------- | ------------ | -------------------------------------------------------------------------- |
-| `f_bus`         |         | `Any`          |                  | always       | id of from-side bus connection                                             |
-| `t_bus`         |         | `Any`          |                  | always       | id of to-side bus connection                                               |
-| `f_connections` |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `f_bus` it connects |
-| `t_connections` |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `t_bus` it connects |
-| `linecode`      |         | `Any`          |                  | `!rs && !xs` | id of an associated linecode                                               |
-| `rs`            |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series resistance matrix, `size=(nconductors,nconductors)`                 |
-| `xs`            |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series reactance matrix, `size=(nconductors,nconductors)`                  |
-| `g_fr`          |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side conductance, `size=(nconductors,nconductors)`                    |
-| `b_fr`          |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side susceptance, `size=(nconductors,nconductors)`                    |
-| `g_to`          |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side conductance, `size=(nconductors,nconductors)`                      |
-| `b_to`          |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side susceptance, `size=(nconductors,nconductors)`                      |
-| `length`        | `1.0`   | `Real`         | meter            |              | Length of the line                                                         |
-| `cm_ub`         |         | `Vector{Real}` | amp              | opf          | Symmetrically applicable current rating, `size=nconductors`                |
-| `sm_ub`         |         | `Vector{Real}` | watt             | opf          | Symmetrically applicable power rating, `size=nconductors`                  |
-| `pl_fr`         |         | `Vector{Real}` | watt             |              | Present active power flow on the from-side                                 |
-| `ql_fr`         |         | `Vector{Real}` | watt             |              | Present reactive power flow on the from-side                               |
-| `pl_to`         |         | `Vector{Real}` | watt             |              | Present active power flow on the to-side                                   |
-| `ql_to`         |         | `Vector{Real}` | watt             |              | Present reactive power flow on the to-side                                 |
-| `status`        | `1`     | `Bool`         |                  | always       | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
+| Name             | Default | Type           | Units            | Required     | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ---------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `f_bus`          |         | `Any`          |                  | always       | id of from-side bus connection                                                                              |
+| `t_bus`          |         | `Any`          |                  | always       | id of to-side bus connection                                                                                |
+| `f_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `f_bus` it connects                                  |
+| `t_connections`  |         | `Vector{Any}`  |                  | always       | Indicates for each conductor, to which terminal of the `t_bus` it connects                                  |
+| `linecode`       |         | `Any`          |                  | `!rs && !xs` | id of an associated linecode                                                                                |
+| `rs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series resistance matrix, `size=(nconductors,nconductors)`                                                  |
+| `xs`             |         | `Matrix{Real}` | ohm/meter        | `!linecode`  | Series reactance matrix, `size=(nconductors,nconductors)`                                                   |
+| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side conductance, `size=(nconductors,nconductors)`                                                     |
+| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |              | From-side susceptance, `size=(nconductors,nconductors)`                                                     |
+| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side conductance, `size=(nconductors,nconductors)`                                                       |
+| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |              | To-side susceptance, `size=(nconductors,nconductors)`                                                       |
+| `length`         | `1.0`   | `Real`         | meter            |              | Length of the line                                                                                          |
+| `cm_ub`          |         | `Vector{Real}` | amp              | opf          | Symmetrically applicable current rating, `size=nconductors`                                                 |
+| `sm_ub`          |         | `Vector{Real}` | watt             | opf          | Symmetrically applicable power rating, `size=nconductors`                                                   |
+| `pl_fr`          |         | `Vector{Real}` | watt             |              | Present active power flow on the from-side                                                                  |
+| `ql_fr`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the from-side                                                                |
+| `pl_to`          |         | `Vector{Real}` | watt             |              | Present active power flow on the to-side                                                                    |
+| `ql_to`          |         | `Vector{Real}` | watt             |              | Present reactive power flow on the to-side                                                                  |
+| `status`         | `1`     | `Bool`         |                  | always       | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |         | `Any`          |                  |              | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 - which takes presidence, `cm_ub` or `sm_ub` if both are specified?
 
@@ -169,46 +171,49 @@ These are n-winding (`nwinding`), n-phase (`nphase`), lossy transformers. Note t
 | `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |                                    | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
 | `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |                                    | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
 | `status`         | `1`                                    | `Bool`                 |       | always                             | `1` or `0`. Indicates if component is enabled or disabled, respectively                                        |
+| `{}_time_series` |                                        | `Any`                  |       |                                    | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter    |
 
 #### Assymetric, Lossless, Two-Winding (AL2W) Transformers
 
 Special case of the Generic transformer. These are transformers are assymetric (A), lossless (L) and two-winding (2W). Assymetric refers to the fact that the secondary is always has a `wye` configuration, whilst the primary can be `delta`. The table below indicates alternate, more simple ways to specify the special case of an AL2W Transformer. `xsc` and `rs` cannot be specified for an AL2W transformer.
 
-| Name            | Default               | Type           | Units | Required       | Description                                                                                             |
-| --------------- | --------------------- | -------------- | ----- | -------------- | ------------------------------------------------------------------------------------------------------- |
-| `f_bus`         |                       | `Any`          |       | `!buses`       | Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                   |
-| `t_bus`         |                       | `Any`          |       | `!buses`       | Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                  |
-| `f_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
-| `t_connections` |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`             |
-| `configuration` | `"wye"`               | `String`       |       |                | `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"` |
-| `tm_nom`        | `1.0`                 | `Real`         |       |                | Nominal tap ratio for the transformer (multiplier)                                                      |
-| `tm_ub`         |                       | `Vector{Real}` |       | opf            | Maximum tap ratio for each phase (base=`tm_nom`)                                                        |
-| `tm_lb`         |                       | `Vector{Real}` |       | opf            | Minimum tap ratio for each phase (base=`tm_nom`)                                                        |
-| `tm_set`        | `fill(1.0, nphases)`  | `Vector{Real}` |       |                | Set tap ratio for each phase (base=`tm_nom`)                                                            |
-| `tm_fix`        | `fill(true, nphases)` | `Vector{Real}` |       |                | Indicates for each phase whether the tap ratio is fixed                                                 |
+| Name             | Default               | Type           | Units | Required       | Description                                                                                                 |
+| ---------------- | --------------------- | -------------- | ----- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `f_bus`          |                       | `Any`          |       | `!buses`       | Alternative way to specify `buses`, requires both `f_bus` and `t_bus`                                       |
+| `t_bus`          |                       | `Any`          |       | `!buses`       | Alternative  way to specify `buses`, requires both `f_bus` and `t_bus`                                      |
+| `f_connections`  |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`                 |
+| `t_connections`  |                       | `Vector{Any}`  |       | `!connections` | Alternative way to specify `connections`, requires both `f_connections` and `t_connections`                 |
+| `configuration`  | `"wye"`               | `String`       |       |                | `"wye"` or `"delta"`. Alternative way to specify the from-side configuration, to-side is always `"wye"`     |
+| `tm_nom`         | `1.0`                 | `Real`         |       |                | Nominal tap ratio for the transformer (multiplier)                                                          |
+| `tm_ub`          |                       | `Vector{Real}` |       | opf            | Maximum tap ratio for each phase (base=`tm_nom`)                                                            |
+| `tm_lb`          |                       | `Vector{Real}` |       | opf            | Minimum tap ratio for each phase (base=`tm_nom`)                                                            |
+| `tm_set`         | `fill(1.0, nphases)`  | `Vector{Real}` |       |                | Set tap ratio for each phase (base=`tm_nom`)                                                                |
+| `tm_fix`         | `fill(true, nphases)` | `Vector{Real}` |       |                | Indicates for each phase whether the tap ratio is fixed                                                     |
+| `{}_time_series` |                       | `Any`          |       |                | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 ### Switches (`switch`)
 
 Switches without any of `rs`, `xs`, `g_fr`, `b_fr`, `g_to`, `b_to` defined are assumed to be lossless. If lossy parameters are defined, `switch` objects will be decomposed into virtual `branch` & `bus`, and an ideal `switch`.
 
-| Name            | Default | Type           | Units   | Required | Description                                                                |
-| --------------- | ------- | -------------- | ------- | -------- | -------------------------------------------------------------------------- |
-| `f_bus`         |         | `Any`          |         | always   | id of from-side bus connection                                             |
-| `t_bus`         |         | `Any`          |         | always   | id of to-side bus connection                                               |
-| `f_connections` |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `f_bus` it connects |
-| `t_connections` |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `t_bus` it connects |
-| `cm_ub`         |         | `Vector{Real}` | amp     | opf      | Symmetrically applicable current rating                                    |
-| `sm_ub`         |         | `Vector{Real}` | watt    | opf      | Symmetrically applicable power rating                                      |
-| `rs`            |         | `Matrix{Real}` | ohm     |          | Series resistance matrix, `size=(nphases,nphases)`                         |
-| `xs`            |         | `Matrix{Real}` | ohm     |          | Series reactance matrix, `size=(nphases,nphases)`                          |
-| `g_fr`          |         | `Matrix{Real}` | siemens |          | From-side conductance, `size=(nphases,nphases)`,                           |
-| `b_fr`          |         | `Matrix{Real}` | siemens |          | From-side susceptance, `size=(nphases,nphases)`                            |
-| `g_to`          |         | `Matrix{Real}` | siemens |          | To-side conductance, `size=(nphases,nphases)`                              |
-| `b_to`          |         | `Matrix{Real}` | siemens |          | To-side susceptance, `size=(nphases,nphases)`                              |
-| `psw`           |         | `Vector{Real}` | watt    |          | Present value of active power flow across the switch                       |
-| `qsw`           |         | `Vector{Real}` | var     |          | Present value of reactive power flow across the switch                     |
-| `state`         | `1`     | `Int`          |         | always   | `1`: closed or `0`: open, to indicate state of switch                      |
-| `status`        | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively    |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `f_bus`          |         | `Any`          |         | always   | id of from-side bus connection                                                                              |
+| `t_bus`          |         | `Any`          |         | always   | id of to-side bus connection                                                                                |
+| `f_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `f_bus` it connects                                  |
+| `t_connections`  |         | `Vector{Any}`  |         | always   | Indicates for each conductor, to which terminal of the `t_bus` it connects                                  |
+| `cm_ub`          |         | `Vector{Real}` | amp     | opf      | Symmetrically applicable current rating                                                                     |
+| `sm_ub`          |         | `Vector{Real}` | watt    | opf      | Symmetrically applicable power rating                                                                       |
+| `rs`             |         | `Matrix{Real}` | ohm     |          | Series resistance matrix, `size=(nphases,nphases)`                                                          |
+| `xs`             |         | `Matrix{Real}` | ohm     |          | Series reactance matrix, `size=(nphases,nphases)`                                                           |
+| `g_fr`           |         | `Matrix{Real}` | siemens |          | From-side conductance, `size=(nphases,nphases)`,                                                            |
+| `b_fr`           |         | `Matrix{Real}` | siemens |          | From-side susceptance, `size=(nphases,nphases)`                                                             |
+| `g_to`           |         | `Matrix{Real}` | siemens |          | To-side conductance, `size=(nphases,nphases)`                                                               |
+| `b_to`           |         | `Matrix{Real}` | siemens |          | To-side susceptance, `size=(nphases,nphases)`                                                               |
+| `psw`            |         | `Vector{Real}` | watt    |          | Present value of active power flow across the switch                                                        |
+| `qsw`            |         | `Vector{Real}` | var     |          | Present value of reactive power flow across the switch                                                      |
+| `state`          | `1`     | `Int`          |         | always   | `1`: closed or `0`: open, to indicate state of switch                                                       |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 #### Fuses (`fuse`)
 
@@ -233,53 +238,55 @@ These are objects that have single bus connections. Every object will have at le
 
 ### Shunts (`shunt`)
 
-| Name            | Default | Type           | Units   | Required | Description                                                             |
-| --------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |         | always   | id of bus connection                                                    |
-| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                    |
-| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `gs`            |         | `Matrix{Real}` | siemens | always   | Conductance, `size=(nphases,nphases)`                                   |
-| `bs`            |         | `Matrix{Real}` | siemens | always   | Susceptance, `size=(nphases,nphases)`                                   |
-| `status`        | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                        |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
+| `gs`             |         | `Matrix{Real}` | siemens | always   | Conductance, `size=(nphases,nphases)`                                                                       |
+| `bs`             |         | `Matrix{Real}` | siemens | always   | Susceptance, `size=(nphases,nphases)`                                                                       |
+| `status`         | `1`     | `Bool`         |         | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 #### Shunt Capacitors (`shunt_capacitor`)
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
-| Name            | Default | Type           | Units   | Required | Description                                                                                          |
-| --------------- | ------- | -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |         | always   | id of bus connection                                                                                 |
-| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                             |
-| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only |
-| `bs`            |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                        |
-| `vnom`          |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                         |
-
-Give some examples
+| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                    |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only        |
+| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                               |
+| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 #### Shunt Reactors (`shunt_reactor`)
 
 This is a special case of `shunt` with its own data category for easier tracking.
 
-| Name            | Default | Type           | Units   | Required | Description                                                                                          |
-| --------------- | ------- | -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |         | always   | id of bus connection                                                                                 |
-| `connections`   |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                             |
-| `configuration` | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only |
-| `bs`            |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                        |
-| `vnom`          |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                         |
+| Name             | Default | Type           | Units   | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |         | always   | id of bus connection                                                                                        |
+| `connections`    |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors, `size=nconductors`                                                    |
+| `configuration`  | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`. For `"delta"`, 2 or 3 connections only        |
+| `bs`             |         | `Vector{Real}` | siemens | always   | Conductance, `size=(nconductors,nconductors)`                                                               |
+| `vnom`           |         | `Real`         | volt    | always   | Nominal voltage (multiplier)                                                                                |
+| `{}_time_series` |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 ### Loads (`load`)
 
-| Name            | Default            | Type           | Units | Required | Description                                                                                                                             |
-| --------------- | ------------------ | -------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `bus`           |                    | `Any`          |       | always   | id of bus connection                                                                                                                    |
-| `connections`   |                    | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                                                    |
-| `configuration` | `"wye"`            | `String`       |       | always   | `"wye"` or "`delta`". If `"wye"`, `connections[end]=neutral`                                                                            |
-| `model`         | `"constant_power"` | `String`       |       | always   | `"constant_power"`, `"constant_impedance"`, `"constant_current"`, `"exponential"`, or `"zip"`. Indicates the type of voltage-dependency |
-| `pd_nom`        |                    | `Vector{Real}` | watt  | always   | Nominal active load, with respect to `vnom`, `size=nphases`                                                                             |
-| `qd_nom`        |                    | `Vector{Real}` | var   | always   | Nominal reactive load, with respect to `vnom`, `size=nphases`                                                                           |
-| `vnom`          |                    | `Real`         | volt  | always   | Nominal voltage (multiplier)                                                                                                            |
-| `status`        | `1`                | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                 |
+| Name             | Default            | Type           | Units | Required | Description                                                                                                                             |
+| ---------------- | ------------------ | -------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `bus`            |                    | `Any`          |       | always   | id of bus connection                                                                                                                    |
+| `connections`    |                    | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                                                    |
+| `configuration`  | `"wye"`            | `String`       |       | always   | `"wye"` or "`delta`". If `"wye"`, `connections[end]=neutral`                                                                            |
+| `model`          | `"constant_power"` | `String`       |       | always   | `"constant_power"`, `"constant_impedance"`, `"constant_current"`, `"exponential"`, or `"zip"`. Indicates the type of voltage-dependency |
+| `pd_nom`         |                    | `Vector{Real}` | watt  | always   | Nominal active load, with respect to `vnom`, `size=nphases`                                                                             |
+| `qd_nom`         |                    | `Vector{Real}` | var   | always   | Nominal reactive load, with respect to `vnom`, `size=nphases`                                                                           |
+| `vnom`           |                    | `Real`         | volt  | always   | Nominal voltage (multiplier)                                                                                                            |
+| `status`         | `1`                | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                 |
+| `{}_time_series` |                    | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter                             |
 
 #### `model="exponential"`
 
@@ -301,20 +308,21 @@ This is a special case of `shunt` with its own data category for easier tracking
 
 ### Generators or Induction Machines or Asychronous Machines? (`generator` or `asychronous_machine` or `induction_machine`?)
 
-| Name            | Default | Type           | Units | Required | Description                                                             |
-| --------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |       | always   | id of bus connection                                                    |
-| `connections`   |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                    |
-| `configuration` | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `pg_lb`         |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`        |
-| `pg_ub`         |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`        |
-| `qg_lb`         |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`      |
-| `qg_ub`         |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`      |
-| `pg`            |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`               |
-| `qg`            |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`             |
-| `status`        | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name             | Default | Type           | Units | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                        |
+| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                        |
+| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
+| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                            |
+| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                            |
+| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                          |
+| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                          |
+| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                   |
+| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                 |
+| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
-#### Cost Model
+#### `generator` Cost Model
 
 The generator cost model is specified by the following fields.
 
@@ -325,22 +333,23 @@ The generator cost model is specified by the following fields.
 
 ### Photovoltaic Systems (`solar`)
 
-| Name            | Default | Type           | Units | Required | Description                                                             |
-| --------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------- |
-| `bus`           |         | `Any`          |       | always   | id of bus connection                                                    |
-| `connections`   |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                    |
-| `configuration` | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `pg_lb`         |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`        |
-| `pg_ub`         |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`        |
-| `qg_lb`         |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`      |
-| `qg_ub`         |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`      |
-| `pg`            |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`               |
-| `qg`            |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`             |
-| `status`        | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name             | Default | Type           | Units | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                        |
+| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                        |
+| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
+| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                            |
+| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                            |
+| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                          |
+| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                          |
+| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                   |
+| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                 |
+| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
-#### Irradiation
+#### Irradiation Model
 
-#### Cost Model
+#### `solar` Cost Model
 
 The cost model for a photovoltaic system currently matches that of generators.
 
@@ -359,43 +368,45 @@ A storage object is a flexible component that can represent a variety of energy 
 
 - How to include the inverter model for this? Similar issue as for a PV generator
 
-| Name                   | Default | Type           | Units   | Required | Description                                                             |
-| ---------------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `bus`                  |         | `Any`          |         | always   | id of bus connection                                                    |
-| `connections`          |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                    |
-| `configuration`        | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`            |
-| `energy`               |         | `Real`         | watt-hr | always   | Stored energy                                                           |
-| `energy_ub`            |         | `Real`         |         | opf      |                                                                         |
-| `charge_ub`            |         | `Real`         |         | opf      |                                                                         |
-| `discharge_ub`         |         | `Real`         |         | opf      |                                                                         |
-| `sm_ub`                |         | `Vector{Real}` | watt    | opf      | Power rating, `size=nphases`                                            |
-| `cm_ub`                |         | `Vector{Real}` | amp     | opf      | Current rating, `size=nphases`                                          |
-| `charge_efficiency`    |         | `Real`         |         | always   |                                                                         |
-| `discharge_efficiency` |         | `Real`         |         | always   |                                                                         |
-| `qs_ub`                |         | `Vector{Real}` |         | opf      | Maximum reactive power injection, `size=nphases`                        |
-| `qs_lb`                |         | `Vector{Real}` |         | opf      | Minimum reactive power injection, `size=nphases`                        |
-| `rs`                   |         | `Vector{Real}` | ohm     | always   |                                                                         |
-| `xs`                   |         | `Vector{Real}` | ohm     | always   |                                                                         |
-| `pex`                  |         | `Real`         |         | always   | Total active power standby exogenous flow (loss)                        |
-| `qex`                  |         | `Real`         |         | always   | Total reactive power standby exogenous flow (loss)                      |
-| `ps`                   |         | `Vector{Real}` | watt    |          | Present active power injection                                          |
-| `qs`                   |         | `Vector{Real}` | var     |          | Present reactive power injection                                        |
-| `status`               | `1`     | `Bool`         |         | opf      | `1` or `0`. Indicates if component is enabled or disabled, respectively |
+| Name                   | Default | Type           | Units   | Required | Description                                                                                                 |
+| ---------------------- | ------- | -------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`                  |         | `Any`          |         | always   | id of bus connection                                                                                        |
+| `connections`          |         | `Vector{Any}`  |         | always   | Ordered list of connected conductors                                                                        |
+| `configuration`        | `"wye"` | `String`       |         | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
+| `energy`               |         | `Real`         | watt-hr | always   | Stored energy                                                                                               |
+| `energy_ub`            |         | `Real`         |         | opf      |                                                                                                             |
+| `charge_ub`            |         | `Real`         |         | opf      |                                                                                                             |
+| `discharge_ub`         |         | `Real`         |         | opf      |                                                                                                             |
+| `sm_ub`                |         | `Vector{Real}` | watt    | opf      | Power rating, `size=nphases`                                                                                |
+| `cm_ub`                |         | `Vector{Real}` | amp     | opf      | Current rating, `size=nphases`                                                                              |
+| `charge_efficiency`    |         | `Real`         |         | always   |                                                                                                             |
+| `discharge_efficiency` |         | `Real`         |         | always   |                                                                                                             |
+| `qs_ub`                |         | `Vector{Real}` |         | opf      | Maximum reactive power injection, `size=nphases`                                                            |
+| `qs_lb`                |         | `Vector{Real}` |         | opf      | Minimum reactive power injection, `size=nphases`                                                            |
+| `rs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                             |
+| `xs`                   |         | `Vector{Real}` | ohm     | always   |                                                                                                             |
+| `pex`                  |         | `Real`         |         | always   | Total active power standby exogenous flow (loss)                                                            |
+| `qex`                  |         | `Real`         |         | always   | Total reactive power standby exogenous flow (loss)                                                          |
+| `ps`                   |         | `Vector{Real}` | watt    |          | Present active power injection                                                                              |
+| `qs`                   |         | `Vector{Real}` | var     |          | Present reactive power injection                                                                            |
+| `status`               | `1`     | `Bool`         |         | opf      | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series`       |         | `Any`          |         |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 ### Voltage Sources (`voltage_source`)
 
 A voltage source is a source of power at a set voltage magnitude and angle connected to a slack bus. If `rs` or `xs` are not specified, the voltage source is assumed to be lossless, otherwise virtual `branch` and `bus` will be created in the mathematical model to represent the internal losses of the voltage source.
 
-| Name            | Default         | Type           | Units  | Required | Description                                                                    |
-| --------------- | --------------- | -------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| `bus`           |                 | `Any`          |        | always   | id of bus connection                                                           |
-| `connections`   |                 | `Vector{Any}`  |        | always   | Ordered list of connected conductors                                           |
-| `configuration` | `"wye"`         | `String`       |        | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                   |
-| `vm`            | `ones(nphases)` | `Vector{Real}` | volt   | always   | Voltage magnitude set at slack bus                                             |
-| `va`            | `0.0`           | `Real`         | degree |          | Voltage angle offset at slack bus                                              |
-| `rs`            |                 | `Matrix{Real}` | ohm    |          | Internal series resistance of voltage source, `size=(nconductors,nconductors)` |
-| `xs`            |                 | `Matrix{Real}` | ohm    |          | Internal series reactance of voltage soure, `size=(nconductors,nconductors)`   |
-| `status`        | `1`             | `Bool`         |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively        |
+| Name             | Default         | Type           | Units  | Required | Description                                                                                                 |
+| ---------------- | --------------- | -------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus`            |                 | `Any`          |        | always   | id of bus connection                                                                                        |
+| `connections`    |                 | `Vector{Any}`  |        | always   | Ordered list of connected conductors                                                                        |
+| `configuration`  | `"wye"`         | `String`       |        | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
+| `vm`             | `ones(nphases)` | `Vector{Real}` | volt   | always   | Voltage magnitude set at slack bus                                                                          |
+| `va`             | `0.0`           | `Real`         | degree |          | Voltage angle offset at slack bus                                                                           |
+| `rs`             |                 | `Matrix{Real}` | ohm    |          | Internal series resistance of voltage source, `size=(nconductors,nconductors)`                              |
+| `xs`             |                 | `Matrix{Real}` | ohm    |          | Internal series reactance of voltage soure, `size=(nconductors,nconductors)`                                |
+| `status`         | `1`             | `Bool`         |        | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
+| `{}_time_series` |                 | `Any`          |        |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 ## Data Objects (codes, curves, shapes)
 
@@ -408,15 +419,16 @@ Linecodes are easy ways to specify properties common to multiple lines.
 - Should the linecode also include a `cm_ub` and `sm_ub`? I think not. `cm_ub` yes, `sm_ub` does not make sense. `sm_ub`, if desired, should be specified at the line level
 - Does `cmatrix` makes more sense than `g_fr, b_fr, g_to, b_to` when parametrized per length? No, enforce symmetry. If needed place a shunt or inject at low-level.
 
-| Name    | Default | Type           | Units            | Required | Description                                             |
-| ------- | ------- | -------------- | ---------------- | -------- | ------------------------------------------------------- |
-| `rs`    |         | `Matrix{Real}` | ohm/meter        |          | Series resistance, `size=(nconductors,nconductors)`     |
-| `xs`    |         | `Matrix{Real}` | ohm/meter        |          | Series reactance, `size=(nconductors,nconductors)`      |
-| `g_fr`  |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side conductance, `size=(nconductors,nconductors)` |
-| `b_fr`  |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side susceptance, `size=(nconductors,nconductors)` |
-| `g_to`  |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side conductance, `size=(nconductors,nconductors)`   |
-| `b_to`  |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side susceptance, `size=(nconductors,nconductors)`   |
-| `cm_ub` |         | `Vector{Real}` | ampere           |          | maximum current per conductor, symmetrically applicable |
+| Name             | Default | Type           | Units            | Required | Description                                                                                                 |
+| ---------------- | ------- | -------------- | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `rs`             |         | `Matrix{Real}` | ohm/meter        |          | Series resistance, `size=(nconductors,nconductors)`                                                         |
+| `xs`             |         | `Matrix{Real}` | ohm/meter        |          | Series reactance, `size=(nconductors,nconductors)`                                                          |
+| `g_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side conductance, `size=(nconductors,nconductors)`                                                     |
+| `b_fr`           |         | `Matrix{Real}` | siemens/meter/Hz |          | From-side susceptance, `size=(nconductors,nconductors)`                                                     |
+| `g_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side conductance, `size=(nconductors,nconductors)`                                                       |
+| `b_to`           |         | `Matrix{Real}` | siemens/meter/Hz |          | To-side susceptance, `size=(nconductors,nconductors)`                                                       |
+| `cm_ub`          |         | `Vector{Real}` | ampere           |          | maximum current per conductor, symmetrically applicable                                                     |
+| `{}_time_series` |         | `Any`          |                  |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
 
 ### Transformer Codes (`xfmrcode`)
 
@@ -432,8 +444,9 @@ Transformer codes are easy ways to specify properties common to multiple transfo
 | `tm_lb`          |                                        | `Vector{Vector{Real}}` |       |          | Minimum tap ratio for for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                |
 | `tm_set`         | `fill(fill(1.0, nphases), nwindings)`  | `Vector{Vector{Real}}` |       |          | Set tap ratio for each winding and phase, `size=((nphases), nwindings)` (base=`tm_nom`)                        |
 | `tm_fix`         | `fill(fill(true, nphases), nwindings)` | `Vector{Vector{Bool}}` |       |          | Indicates for each winding and phase whether the tap ratio is fixed, `size=((nphases), nwindings)`             |
+| `{}_time_series` |                                        | `Any`                  |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter    |
 
-### Voltage Zones (`voltagezone`)
+### Voltage Zones (`voltage_zone`)
 
 Voltage zones are a convenient way to specify voltage bounds for a set of three-phase buses (ones with `phases`/`neutral` properties).
 
@@ -457,6 +470,8 @@ Curve objects are functions f(x) that return single values for a given x. This i
 ### Time Series (`time_series`)
 
 Time series objects are used to specify time series for _e.g._ load or generation forecasts.
+
+Every parameter for any component specified in this document can support a time series by appending `_time_series` to the parameter name. For example, for a `load`, if `pd_nom` is supposed to be a time series, the user would specify `"pd_nom_time_series" => time_series_id` where `time_series_id` is the `id` of an object in `time_series`, and has type `Any`.
 
 | Name         | Default | Type           | Units | Required | Description                                                                                                                                                         |
 | ------------ | ------- | -------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/data_model_eng.md
+++ b/data_model_eng.md
@@ -14,7 +14,7 @@ The data structure is in the following format
 Dict{String,Any}(
     "component_type" => Dict{Any,Dict{String,Any}}(
         id => Dict{String,Any}(
-            "field" => value,
+            "parameter" => value,
             ...
         ),
         ...
@@ -306,21 +306,22 @@ This is a special case of `shunt` with its own data category for easier tracking
 | `qd_nom_i` |         | `Real` |       | `model=="zip"` |             |
 | `qd_nom_p` |         | `Real` |       | `model=="zip"` |             |
 
-### Generators or Induction Machines or Asychronous Machines? (`generator` or `asychronous_machine` or `induction_machine`?)
+### Generators `generator` (or Synchronous Machines `synchronous_machine`?)
 
-| Name             | Default | Type           | Units | Required | Description                                                                                                 |
-| ---------------- | ------- | -------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                        |
-| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                        |
-| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                |
-| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                            |
-| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                            |
-| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                          |
-| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                          |
-| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                   |
-| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                 |
-| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                     |
-| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter |
+| Name             | Default | Type           | Units | Required | Description                                                                                                                                                                                                     |
+| ---------------- | ------- | -------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bus`            |         | `Any`          |       | always   | id of bus connection                                                                                                                                                                                            |
+| `connections`    |         | `Vector{Any}`  |       | always   | Ordered list of connected conductors                                                                                                                                                                            |
+| `configuration`  | `"wye"` | `String`       |       | always   | `"wye"` or `"delta"`. If `"wye"`, `connections[end]=neutral`                                                                                                                                                    |
+| `model`          | `1`     | `Int`          |       | always   | Model of the generator. `1`: Constant P,Q; `2`: Constant P,\|V\|; `3`: Constant Z; `4`: Current-limited, constant P,Q (e.g. some inverters).  `1` and `2` supported, other models have plans for future support |
+| `pg_lb`          |         | `Vector{Real}` | watt  | opf      | Lower bound on active power generation per phase, `size=nphases`                                                                                                                                                |
+| `pg_ub`          |         | `Vector{Real}` | watt  | opf      | Upper bound on active power generation per phase, `size=nphases`                                                                                                                                                |
+| `qg_lb`          |         | `Vector{Real}` | var   | opf      | Lower bound on reactive power generation per phase, `size=nphases`                                                                                                                                              |
+| `qg_ub`          |         | `Vector{Real}` | var   | opf      | Upper bound on reactive power generation per phase, `size=nphases`                                                                                                                                              |
+| `pg`             |         | `Vector{Real}` | watt  |          | Present active power generation per phase, `size=nphases`                                                                                                                                                       |
+| `qg`             |         | `Vector{Real}` | var   |          | Present reactive power generation per phase, `size=nphases`                                                                                                                                                     |
+| `status`         | `1`     | `Bool`         |       | always   | `1` or `0`. Indicates if component is enabled or disabled, respectively                                                                                                                                         |
+| `{}_time_series` |         | `Any`          |       |          | id of `time_series` object that will replace the values of parameter given by `{}`. Valid for any parameter                                                                                                     |
 
 #### `generator` Cost Model
 
@@ -360,7 +361,7 @@ The cost model for a photovoltaic system currently matches that of generators.
 
 ### Wind Turbine Systems (`wind`)
 
-TODO
+Wind turbine systems are most closely approximated by induction machines, also known as asynchornous machines. These are not currently supported, but there is plans to support them in the future.
 
 ### Storage (`storage`)
 


### PR DESCRIPTION
adds a required column to all tables, and updates variable names to
match the common electric power transmission system model proposal
where matching makes sense (_lb, _ub instead of _min, _max, _rating
to _ub, etc.)